### PR TITLE
Feat/#73 매칭 로직 고도화

### DIFF
--- a/src/docs/asciidoc/matching.adoc
+++ b/src/docs/asciidoc/matching.adoc
@@ -27,6 +27,16 @@ include::{snippets}/matching-application-get/http-request.adoc[]
 
 include::{snippets}/matching-application-get/http-response.adoc[]
 
+=== 매칭 시작 시간 조회
+
+==== HTTP request
+
+include::{snippets}/matching-begin-time-get/http-request.adoc[]
+
+==== HTTP response
+
+include::{snippets}/matching-begin-time-get/http-response.adoc[]
+
 === 매칭 신청 취소
 
 ==== HTTP request
@@ -46,3 +56,4 @@ include::{snippets}/matching-process-get-partners/http-request.adoc[]
 ==== HTTP response
 
 include::{snippets}/matching-process-get-partners/http-response.adoc[]
+

--- a/src/docs/asciidoc/matching.adoc
+++ b/src/docs/asciidoc/matching.adoc
@@ -37,6 +37,16 @@ include::{snippets}/matching-begin-time-get/http-request.adoc[]
 
 include::{snippets}/matching-begin-time-get/http-response.adoc[]
 
+=== 매칭 신청 정보 수정
+
+==== HTTP request
+
+include::{snippets}/matching-application-modify/http-request.adoc[]
+
+==== HTTP response
+
+include::{snippets}/matching-application-modify/http-response.adoc[]
+
 === 매칭 신청 취소
 
 ==== HTTP request

--- a/src/main/java/com/aliens/backend/global/response/SuccessResponse.java
+++ b/src/main/java/com/aliens/backend/global/response/SuccessResponse.java
@@ -4,10 +4,6 @@ import com.aliens.backend.global.response.success.SuccessCode;
 import org.springframework.http.ResponseEntity;
 
 public class SuccessResponse<T> extends ResponseEntity {
-    public SuccessResponse(final SuccessCode successCode) {
-        super(successCode.getHttpStatus());
-    }
-
     public SuccessResponse(final SuccessCode successCode, final T result) {
         super(new CustomResponseDto<>(successCode.getCode(), result),
                 successCode.getHttpStatus()
@@ -19,6 +15,6 @@ public class SuccessResponse<T> extends ResponseEntity {
     }
 
     public static SuccessResponse of(final SuccessCode successCode) {
-        return new SuccessResponse(successCode);
+        return new SuccessResponse(successCode, successCode.getMessage());
     }
 }

--- a/src/main/java/com/aliens/backend/global/response/SuccessResponse.java
+++ b/src/main/java/com/aliens/backend/global/response/SuccessResponse.java
@@ -4,6 +4,9 @@ import com.aliens.backend.global.response.success.SuccessCode;
 import org.springframework.http.ResponseEntity;
 
 public class SuccessResponse<T> extends ResponseEntity {
+    public SuccessResponse(final SuccessCode successCode) {
+        super(successCode.getHttpStatus());
+    }
 
     public SuccessResponse(final SuccessCode successCode, final T result) {
         super(new CustomResponseDto<>(successCode.getCode(), result),
@@ -13,5 +16,9 @@ public class SuccessResponse<T> extends ResponseEntity {
 
     public static <T> SuccessResponse<T> of(final SuccessCode successCode, final T result) {
         return new SuccessResponse<>(successCode, result);
+    }
+
+    public static SuccessResponse of(final SuccessCode successCode) {
+        return new SuccessResponse(successCode);
     }
 }

--- a/src/main/java/com/aliens/backend/global/response/success/MatchingSuccess.java
+++ b/src/main/java/com/aliens/backend/global/response/success/MatchingSuccess.java
@@ -8,6 +8,7 @@ public enum MatchingSuccess implements SuccessCode {
     CANCEL_MATCHING_APPLICATION_SUCCESS(HttpStatus.OK, "MA003", "매칭 신청 취소 성공"),
     GET_MATCHING_PARTNERS_SUCCESS(HttpStatus.OK, "MA004", "매칭 파트너 조회 성공"),
     GET_MATCHING_BEGIN_TIME_SUCCESS(HttpStatus.OK, "MA005", "매칭까지 남은 시간 조회 성공"),
+    MODIFY_MATCHING_APPLICATION_INFO_SUCCESS(HttpStatus.OK, "MA006", "매칭 신청 정보 수정 성공"),
 
     ;
 

--- a/src/main/java/com/aliens/backend/global/response/success/MatchingSuccess.java
+++ b/src/main/java/com/aliens/backend/global/response/success/MatchingSuccess.java
@@ -7,6 +7,7 @@ public enum MatchingSuccess implements SuccessCode {
     GET_MATCHING_APPLICATION_STATUS_SUCCESS(HttpStatus.OK, "MA002", "매칭 신청 정보 조회 성공"),
     CANCEL_MATCHING_APPLICATION_SUCCESS(HttpStatus.OK, "MA003", "매칭 신청 취소 성공"),
     GET_MATCHING_PARTNERS_SUCCESS(HttpStatus.OK, "MA004", "매칭 파트너 조회 성공"),
+    GET_MATCHING_BEGIN_TIME_SUCCESS(HttpStatus.OK, "MA005", "매칭까지 남은 시간 조회 성공"),
 
     ;
 

--- a/src/main/java/com/aliens/backend/mathcing/controller/MatchingApplicationController.java
+++ b/src/main/java/com/aliens/backend/mathcing/controller/MatchingApplicationController.java
@@ -7,6 +7,7 @@ import com.aliens.backend.global.response.success.MatchingSuccess;
 import com.aliens.backend.global.validator.LanguageCheck;
 import com.aliens.backend.mathcing.controller.dto.request.MatchingApplicationRequest;
 import com.aliens.backend.mathcing.controller.dto.response.MatchingApplicationResponse;
+import com.aliens.backend.mathcing.controller.dto.response.MatchingBeginTimeResponse;
 import com.aliens.backend.mathcing.service.MatchingApplicationService;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,6 +31,12 @@ public class MatchingApplicationController {
     public SuccessResponse<MatchingApplicationResponse> getMatchingApplication(final @Login LoginMember loginMember) {
         return SuccessResponse.of(MatchingSuccess.GET_MATCHING_APPLICATION_STATUS_SUCCESS,
                 matchingApplicationService.findMatchingApplication(loginMember));
+    }
+
+    @GetMapping("/applications/begin-time")
+    public SuccessResponse<MatchingBeginTimeResponse> getMatchingBeginTime() {
+        return SuccessResponse.of(MatchingSuccess.GET_MATCHING_BEGIN_TIME_SUCCESS,
+                matchingApplicationService.findMatchingBeginTime());
     }
 
     @DeleteMapping("/applications")

--- a/src/main/java/com/aliens/backend/mathcing/controller/MatchingApplicationController.java
+++ b/src/main/java/com/aliens/backend/mathcing/controller/MatchingApplicationController.java
@@ -12,7 +12,7 @@ import com.aliens.backend.mathcing.service.MatchingApplicationService;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/matchings")
+@RequestMapping("/matchings/applications")
 public class MatchingApplicationController {
     private final MatchingApplicationService matchingApplicationService;
 
@@ -20,26 +20,33 @@ public class MatchingApplicationController {
         this.matchingApplicationService = matchingApplicationService;
     }
 
-    @PostMapping("/applications")
+    @PostMapping
     public SuccessResponse<String> applyMatch(final @Login LoginMember loginMember,
                                               final @RequestBody @LanguageCheck MatchingApplicationRequest matchingApplicationRequest) {
         return SuccessResponse.of(MatchingSuccess.APPLY_MATCHING_SUCCESS,
                 matchingApplicationService.saveParticipant(loginMember, matchingApplicationRequest));
     }
 
-    @GetMapping("/applications")
+    @GetMapping
     public SuccessResponse<MatchingApplicationResponse> getMatchingApplication(final @Login LoginMember loginMember) {
         return SuccessResponse.of(MatchingSuccess.GET_MATCHING_APPLICATION_STATUS_SUCCESS,
                 matchingApplicationService.findMatchingApplication(loginMember));
     }
 
-    @GetMapping("/applications/begin-time")
+    @GetMapping("/begin-time")
     public SuccessResponse<MatchingBeginTimeResponse> getMatchingBeginTime() {
         return SuccessResponse.of(MatchingSuccess.GET_MATCHING_BEGIN_TIME_SUCCESS,
                 matchingApplicationService.findMatchingBeginTime());
     }
 
-    @DeleteMapping("/applications")
+    @PutMapping
+    public SuccessResponse<?> modifyMatchingApplication(final @Login LoginMember loginMember,
+                                                        final @RequestBody @LanguageCheck MatchingApplicationRequest matchingApplicationRequest) {
+        matchingApplicationService.modifyMatchingApplication(loginMember, matchingApplicationRequest);
+        return SuccessResponse.of(MatchingSuccess.MODIFY_MATCHING_APPLICATION_INFO_SUCCESS);
+    }
+
+    @DeleteMapping
     public SuccessResponse<String> cancelMatchingApplication(final @Login LoginMember loginMember) {
         return SuccessResponse.of(MatchingSuccess.CANCEL_MATCHING_APPLICATION_SUCCESS,
                 matchingApplicationService.cancelMatchingApplication(loginMember));

--- a/src/main/java/com/aliens/backend/mathcing/controller/dto/response/MatchingBeginTimeResponse.java
+++ b/src/main/java/com/aliens/backend/mathcing/controller/dto/response/MatchingBeginTimeResponse.java
@@ -1,0 +1,14 @@
+package com.aliens.backend.mathcing.controller.dto.response;
+
+import com.aliens.backend.mathcing.domain.MatchingRound;
+
+import java.time.LocalDateTime;
+
+public record MatchingBeginTimeResponse(
+    Long round,
+    LocalDateTime matchingBeginTime
+) {
+    public static MatchingBeginTimeResponse from(MatchingRound matchingRound) {
+        return new MatchingBeginTimeResponse(matchingRound.getRound(), matchingRound.getValidStartTime());
+    }
+}

--- a/src/main/java/com/aliens/backend/mathcing/domain/MatchingApplication.java
+++ b/src/main/java/com/aliens/backend/mathcing/domain/MatchingApplication.java
@@ -54,6 +54,11 @@ public class MatchingApplication {
                 matchingApplicationRequest.secondPreferLanguage());
     }
 
+    public void modifyTo(final MatchingApplicationRequest matchingApplicationRequest) {
+        this.firstPreferLanguage = matchingApplicationRequest.firstPreferLanguage();
+        this.secondPreferLanguage = matchingApplicationRequest.secondPreferLanguage();
+    }
+
     public Member getMember() {
         return id.getMember();
     }

--- a/src/main/java/com/aliens/backend/mathcing/domain/MatchingResult.java
+++ b/src/main/java/com/aliens/backend/mathcing/domain/MatchingResult.java
@@ -29,6 +29,20 @@ public class MatchingResult {
         return new MatchingResult(MatchingResultId.of(matchingRound, participant.member(), partner.member()), partner.relationship());
     }
 
+    public void matchEach() {
+        Member matchingMember = getMatchingMember();
+        Member matchedMember = getMatchedMember();
+        matchingMember.matched();
+        matchedMember.matched();
+    }
+
+    public void expireMatch() {
+        Member matchingMember = getMatchingMember();
+        Member matchedMember = getMatchedMember();
+        matchingMember.expireMatch();
+        matchedMember.expireMatch();
+    }
+
     public MatchingRound getMatchingRound() {
         return id.getMatchingRound();
     }

--- a/src/main/java/com/aliens/backend/mathcing/service/MatchingApplicationService.java
+++ b/src/main/java/com/aliens/backend/mathcing/service/MatchingApplicationService.java
@@ -9,6 +9,7 @@ import com.aliens.backend.global.response.error.MemberError;
 import com.aliens.backend.global.response.success.MatchingSuccess;
 import com.aliens.backend.mathcing.controller.dto.request.MatchingApplicationRequest;
 import com.aliens.backend.mathcing.controller.dto.response.MatchingApplicationResponse;
+import com.aliens.backend.mathcing.controller.dto.response.MatchingBeginTimeResponse;
 import com.aliens.backend.mathcing.domain.MatchingApplication;
 import com.aliens.backend.mathcing.domain.MatchingRound;
 import com.aliens.backend.mathcing.domain.repository.MatchingApplicationRepository;
@@ -61,6 +62,12 @@ public class MatchingApplicationService {
         MatchingApplication matchingApplication = getMatchingApplication(currentRound, loginMember);
         cancelForMatching(matchingApplication);
         return MatchingSuccess.CANCEL_MATCHING_APPLICATION_SUCCESS.getMessage();
+    }
+
+    @Transactional(readOnly = true)
+    public MatchingBeginTimeResponse findMatchingBeginTime() {
+        MatchingRound currentRound = getCurrentRound();
+        return MatchingBeginTimeResponse.from(currentRound);
     }
 
     private MatchingRound getCurrentRound() {

--- a/src/main/java/com/aliens/backend/mathcing/service/MatchingApplicationService.java
+++ b/src/main/java/com/aliens/backend/mathcing/service/MatchingApplicationService.java
@@ -70,6 +70,15 @@ public class MatchingApplicationService {
         return MatchingBeginTimeResponse.from(currentRound);
     }
 
+    @Transactional
+    public void modifyMatchingApplication(final LoginMember loginMember,
+                                          final MatchingApplicationRequest matchingApplicationRequest) {
+        MatchingRound currentRound = getCurrentRound();
+        checkReceptionTime(currentRound);
+        MatchingApplication matchingApplication = getMatchingApplication(currentRound, loginMember);
+        matchingApplication.modifyTo(matchingApplicationRequest);
+    }
+
     private MatchingRound getCurrentRound() {
         return matchingRoundRepository.findCurrentRound()
                 .orElseThrow(()-> new RestApiException(MatchingError.NOT_FOUND_MATCHING_ROUND));

--- a/src/main/java/com/aliens/backend/mathcing/service/MatchingProcessService.java
+++ b/src/main/java/com/aliens/backend/mathcing/service/MatchingProcessService.java
@@ -71,7 +71,7 @@ public class MatchingProcessService {
     @Transactional
     public void expireMatching() {
         List<MatchingResult> previousMatchingResults = getPreviousMatchingResults();
-        previousMatchingResults.forEach(this::resetMatch);
+        previousMatchingResults.forEach(MatchingResult::expireMatch);
         eventPublisher.expireChatRoom(previousMatchingResults);
     }
 
@@ -123,17 +123,7 @@ public class MatchingProcessService {
 
     private void matchBetween(final MatchingResult matchingResult) {
         matchingResultRepository.save(matchingResult);
-        Member matchingMember = matchingResult.getMatchingMember();
-        Member matchedMember = matchingResult.getMatchedMember();
-        matchingMember.matched();
-        matchedMember.matched();
-    }
-
-    private void resetMatch(MatchingResult matchingResult) {
-        Member matchingMember = matchingResult.getMatchingMember();
-        Member matchedMember = matchingResult.getMatchedMember();
-        matchingMember.expireMatch();
-        matchedMember.expireMatch();
+        matchingResult.matchEach();
     }
 
     private MatchingOperateRequest createOperateRequest(final MatchingRound matchingRound) {

--- a/src/test/java/com/aliens/backend/docs/MatchingDocTest.java
+++ b/src/test/java/com/aliens/backend/docs/MatchingDocTest.java
@@ -149,6 +149,29 @@ class MatchingDocTest extends BaseServiceTest {
                         )));
     }
 
+    @Test
+    @DisplayName("API - 매칭 신청 정보 수정")
+    void modifyMatchingApplicationTest() throws Exception {
+        // given
+        createSingleMember();
+        LoginMember loginMember = member.getLoginMember();
+        matchingApplicationService.saveParticipant(loginMember, request);
+        MatchingApplicationRequest modifyRequest = new MatchingApplicationRequest(Language.JAPANESE, Language.ENGLISH);
+
+        // when & then
+        mockMvc.perform(put(baseUrl + "/applications")
+                        .header("Authorization", GIVEN_ACCESS_TOKEN)
+                        .content(objectMapper.writeValueAsString(modifyRequest))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("matching-application-modify",
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("매칭 신청 정보 수정 결과")
+                        )));
+    }
+
     private void createSingleMember() {
         member = dummyGenerator.generateSingleMember();
         GIVEN_ACCESS_TOKEN = dummyGenerator.generateAccessToken(member);

--- a/src/test/java/com/aliens/backend/docs/MatchingDocTest.java
+++ b/src/test/java/com/aliens/backend/docs/MatchingDocTest.java
@@ -96,6 +96,20 @@ class MatchingDocTest extends BaseServiceTest {
     }
 
     @Test
+    @DisplayName("API - 매칭 시작 시간 조회")
+    void getMatchingBeginTimeTest() throws Exception {
+        mockMvc.perform(get(baseUrl + "/applications/begin-time"))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("matching-begin-time-get",
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("매칭 시작 시간 조회 결과"),
+                                fieldWithPath("result.round").description("매칭 회차"),
+                                fieldWithPath("result.matchingBeginTime").description("매칭 시작 시간")
+                        )));
+    }
+
+    @Test
     @DisplayName("API - 매칭 신청 취소")
     void cancelMatchingApplicationTest() throws Exception {
         // given

--- a/src/test/java/com/aliens/backend/matching/unit/service/MatchingApplicationServiceTest.java
+++ b/src/test/java/com/aliens/backend/matching/unit/service/MatchingApplicationServiceTest.java
@@ -71,6 +71,24 @@ class MatchingApplicationServiceTest extends BaseServiceTest {
         assertThat(result.getMemberId()).isEqualTo(expectedResult);
     }
 
+
+    @Test
+    @DisplayName("매칭 신청 정보 수정 테스트")
+    void modifyMatchingApplicationTest() {
+        // given
+        createMember();
+        mockClock.mockTime(VALID_RECEPTION_TIME_ON_TUESDAY);
+        matchingApplicationService.saveParticipant(loginMember, matchingApplicationRequest);
+        MatchingApplicationRequest modifyRequest = new MatchingApplicationRequest(Language.JAPANESE, Language.ENGLISH);
+
+        // when
+        matchingApplicationService.modifyMatchingApplication(loginMember, modifyRequest);
+
+        // then
+        MatchingApplication result = findMatchingApplication(loginMember);
+        assertThat(result.getFirstPreferLanguage()).isEqualTo(modifyRequest.firstPreferLanguage());
+    }
+
     @Test
     @DisplayName("매칭된 회원들이 다음 매칭 신청")
     void applyNextMatch() {


### PR DESCRIPTION
… 매칭을 만료, 매칭 성사 하도록 변경

<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #74 
- #75

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- 

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
매칭이 시작 되기까지 남은 시간을 출력하는 화면이 필요합니다.

어느 방법이 더 적합할까요? 
1. 백엔드에서 매칭이 시작 되기까지 남은 시간을 계산해서 반환
2. 백엔드에서 매칭이 시작되는 시간을 반환한다음, 프론트가 반환받은 매칭 시작 시간으로
(매칭 시작 시간) - (현재 시간)을 계산하여 매칭이 시작되기까지 남은 시간을 화면에 출력

서버와 클라이언트 사이의 시간 동기화 문제를 고려하면, 두 번째 방법이 더 적절합니다.

백엔드에서 매칭이 시작되는 시간을 반환하고, 프론트엔드에서 해당 시간과 현재 시간 사이의 차이를 계산하는 방법을 사용하면, 클라이언트의 시간 설정이 서버와 다르더라도 사용자에게 정확한 남은 시간을 보여줄 수 있습니다. 
따라서, 프론트엔드에서 해당 시간을 받아 사용자의 기기 시간과 비교하여 남은 시간을 계산하는 방식으로 구현합니다.