### PR TITLE
Feat/#29 board 도메인 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,23 @@
   <img src="https://github.com/Re-4aliens/backend/assets/86913355/13863e52-671b-4b3d-95c6-ab620a3326db" height="350px" width="160px">  
 </p>
 
-  FriendShip은 외국인과 한국인간의 소통을 위한 창구를 제공하기 위한 서비스입니다.
+FriendShip은 외국인과 한국인간의 소통을 위한 창구를 제공하기 위한 서비스입니다.
 
-  일주일에 두 번의 매칭을 통한 3일간의 채팅, 게시판 기능을  제공합니다. 
-  
+일주일에 두 번의 매칭을 통한 3일간의 채팅, 게시판 기능을  제공합니다.
 
- -  GooglePlay URL : https://play.google.com/store/apps/details?id=com.aliens.friendship
 
- -  AppStore URL : https://apps.apple.com/kr/app/friendship/id6466155577
+-  GooglePlay URL : https://play.google.com/store/apps/details?id=com.aliens.friendship
+
+-  AppStore URL : https://apps.apple.com/kr/app/friendship/id6466155577
 
 
 ---
 
 **사용된 기술**
 
-Programming -  SpringBoot 3.2.1, Gradle 
+Programming -  SpringBoot 3.2.1, Gradle
 
-Database - MySQL, MongoDB 
+Database - MySQL, MongoDB
 
 Server - AWS S3, AWS rds mysql, Putty
 
@@ -66,7 +66,7 @@ Notification - Firebase Cloud Messaging (FCM)
 
 ---
 
-**학습 동기화 자료** 
+**학습 동기화 자료**
 - [Parallel Stream을 써야할 때는 언제인가](https://hulking-edge-c2d.notion.site/Parallel-Stream-a7c38612b59c48e0a80231a1ac826775?pvs=4)
 - [DDD : 비즈니스 로직과 요구사항을 코드에 직접적으로 반영하는 방법론](https://hulking-edge-c2d.notion.site/DDD-899ad5e7416848f182b607c81bf3f0cf?pvs=4)
 - [TDD : 테스트 주도 개발 방법론](https://hulking-edge-c2d.notion.site/TDD-d299dfa108c244d9a6820cfa776fd983?pvs=4)
@@ -78,11 +78,11 @@ Notification - Firebase Cloud Messaging (FCM)
 
 ---
 
-**협업 자료** 
+**협업 자료**
 
 - [요구사항 정의서](https://hulking-edge-c2d.notion.site/d49730579f1149e98d137eafb0b1a72c?pvs=4)
 - [DDD 설계](https://www.figma.com/file/vrduvG2YiZCX4aQzGic4jt?type=design)
-  
+
 ---
 **협업 전략 (git, rule)**
 

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,29 @@ dependencies {
 
     //FCM
     implementation 'com.google.firebase:firebase-admin:9.1.1'
+
+    //QUERY_DSL
+    implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+    implementation "com.querydsl:querydsl-core:5.0.0"
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 }
+
+def querydslDir = "build/generated/querydsl"
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
+}
+
 
 ext {
     snippetsDir = file('build/generated-snippets')

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -11,6 +11,7 @@
 
 ==== HTTP request
 include::{snippets}/member-signup/http-request.adoc[]
+include::{snippets}/member-signup/request-parts.adoc[]
 
 
 ==== HTTP response
@@ -25,6 +26,7 @@ include::{snippets}/member-signup/response-fields.adoc[]
 
 ==== HTTP request
 include::{snippets}/member-change-profile-image/http-request.adoc[]
+include::{snippets}/member-change-profile-image/request-parts.adoc[]
 
 ==== HTTP response
 include::{snippets}/member-change-profile-image/http-response.adoc[]

--- a/src/main/java/com/aliens/backend/BackendApplication.java
+++ b/src/main/java/com/aliens/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package com.aliens.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication
 public class BackendApplication {

--- a/src/main/java/com/aliens/backend/board/controller/BoardController.java
+++ b/src/main/java/com/aliens/backend/board/controller/BoardController.java
@@ -1,0 +1,87 @@
+package com.aliens.backend.board.controller;
+
+
+import com.aliens.backend.auth.controller.dto.LoginMember;
+import com.aliens.backend.board.controller.dto.request.BoardCreateRequest;
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.service.BoardReadService;
+import com.aliens.backend.board.service.BoardService;
+import com.aliens.backend.global.config.resolver.Login;
+import com.aliens.backend.global.response.SuccessResponse;
+import com.aliens.backend.global.response.success.BoardSuccess;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RequestMapping("/boards")
+@RestController
+public class BoardController {
+
+    private final BoardService boardService;
+    private final BoardReadService boardReadService;
+
+    public BoardController(final BoardService boardService, final BoardReadService boardReadService) {
+        this.boardService = boardService;
+        this.boardReadService = boardReadService;
+    }
+
+    @PostMapping("/normal")
+    public SuccessResponse<?> createBoard(@Login final LoginMember loginMember,
+                                       @RequestBody final BoardCreateRequest request,
+                                       @RequestPart final List<MultipartFile> boardImages) {
+        boardService.postNormalBoard(request, boardImages, loginMember);
+        return SuccessResponse.of(BoardSuccess.POST_BOARD_SUCCESS);
+    }
+
+    @GetMapping
+    public SuccessResponse<List<BoardResponse>> getAllBoards(@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return SuccessResponse.of(BoardSuccess.GET_ALL_BOARDS_SUCCESS,
+                boardReadService.getBoardPage(pageable));
+    }
+
+    @GetMapping("/category")
+    public SuccessResponse<List<BoardResponse>> getAllBoardsWithCategory(@RequestParam final String category,
+                                                                         @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+        return SuccessResponse.of(BoardSuccess.GET_ALL_BOARDS_WITH_CATEGORY_SUCCESS,
+                boardReadService.getBoardPageWithCategory(category,pageable));
+    }
+
+    @GetMapping("/search")
+    public SuccessResponse<List<BoardResponse>> searchAllBoardPage(@RequestParam("search-keyword") final String searchKeyword,
+                                                                   @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+        return SuccessResponse.of(BoardSuccess.SEARCH_ALL_BOARDS_SUCCESS,
+                boardReadService.searchBoardPageWithKeyword(searchKeyword,pageable));
+    }
+
+    @GetMapping("/announcements")
+    public SuccessResponse<List<BoardResponse>> getAllAnnouncementBoards(@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+        return SuccessResponse.of(BoardSuccess.GET_ALL_ANNOUNCEMENT_BOARDS_SUCCESS,
+                boardReadService.getAnnouncePage(pageable));
+    }
+
+    @GetMapping("/writes")
+    public SuccessResponse<List<BoardResponse>> getPageMyBoards(@Login LoginMember loginMember,
+                                                                @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+        return SuccessResponse.of(BoardSuccess.GET_MY_BOARD_PAGE_SUCCESS,
+                boardReadService.getMyBoardPage(loginMember, pageable));
+    }
+
+    @GetMapping("/category/search")
+    public SuccessResponse<List<BoardResponse>> searchBoardsWithCategory(@RequestParam("search-keyword") final String searchKeyword,
+                                                                         @RequestParam("category") final String category,
+                                                                         @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+        return SuccessResponse.of(BoardSuccess.SEARCH_BOARD_WITH_CATEGORY_SUCCESS,
+                boardReadService.searchBoardPageWithKeywordAndCategory(searchKeyword, category, pageable));
+    }
+
+    @DeleteMapping
+    public SuccessResponse<?> deleteBoard(@Login final LoginMember loginMember,
+                            @RequestParam("id") final Long id) {
+        boardService.deleteBoard(loginMember, id);
+        return SuccessResponse.of(BoardSuccess.DELETE_BOARD_SUCCESS);
+    }
+}

--- a/src/main/java/com/aliens/backend/board/controller/CommentController.java
+++ b/src/main/java/com/aliens/backend/board/controller/CommentController.java
@@ -1,0 +1,64 @@
+package com.aliens.backend.board.controller;
+
+import com.aliens.backend.auth.controller.dto.LoginMember;
+import com.aliens.backend.board.controller.dto.response.CommentResponse;
+import com.aliens.backend.board.controller.dto.request.ParentCommentCreateRequest;
+import com.aliens.backend.board.controller.dto.request.ChildCommentCreateRequest;
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.service.CommentService;
+import com.aliens.backend.global.config.resolver.Login;
+import com.aliens.backend.global.response.SuccessResponse;
+import com.aliens.backend.global.response.success.CommentSuccess;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+@RestController
+public class CommentController {
+    private final CommentService commentService;
+
+    public CommentController(final CommentService commentService) {
+        this.commentService = commentService;
+    }
+
+    @PostMapping("/comments/parent")
+    public SuccessResponse<?> createParentComment(@RequestBody final ParentCommentCreateRequest request,
+                                                  @Login final LoginMember loginMember) {
+        commentService.postParentComment(request, loginMember);
+
+        return SuccessResponse.of(CommentSuccess.PARENT_COMMENT_CREATE_SUCCESS);
+    }
+
+    @PostMapping("/comments/child")
+    public SuccessResponse<?> createChildComment(@RequestBody final ChildCommentCreateRequest request,
+                                                 @Login final LoginMember loginMember) {
+        commentService.postChildComment(request, loginMember);
+
+        return SuccessResponse.of(CommentSuccess.CHILD_COMMENT_CREATE_SUCCESS);
+    }
+
+    @GetMapping("/comments/my-boards")
+    public SuccessResponse<List<BoardResponse>> getPageMyCommentedBoards(@Login final LoginMember loginMember,
+                                                                         @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+        return SuccessResponse.of(CommentSuccess.GET_MY_COMMENTED_BOARD_PAGE_SUCCESS,
+                commentService.getCommentedBoardPage(loginMember, pageable));
+    }
+
+    @GetMapping("/comments/boards")
+    public SuccessResponse<List<CommentResponse>> getCommentsByBoardId(@RequestParam("board-id") final Long boardId) {
+        return SuccessResponse.of(CommentSuccess.GET_COMMENTS_BY_BOARD_ID_SUCCESS,
+                commentService.getCommentsByBoardId(boardId));
+    }
+
+    @DeleteMapping("/comments")
+    public SuccessResponse<?> deleteComment(@Login final LoginMember loginMember,
+                                            @RequestParam("comment-id") final Long commentId) {
+        commentService.deleteComment(loginMember, commentId);
+
+        return SuccessResponse.of(CommentSuccess.DELETE_COMMENT_SUCCESS);
+    }
+}

--- a/src/main/java/com/aliens/backend/board/controller/GreatController.java
+++ b/src/main/java/com/aliens/backend/board/controller/GreatController.java
@@ -1,0 +1,40 @@
+package com.aliens.backend.board.controller;
+
+import com.aliens.backend.auth.controller.dto.LoginMember;
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.service.GreatService;
+import com.aliens.backend.global.config.resolver.Login;
+import com.aliens.backend.global.response.SuccessResponse;
+import com.aliens.backend.global.response.success.GreatSuccess;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+@RestController
+public class GreatController {
+
+    private final GreatService greatService;
+
+    public GreatController(final GreatService greatService) {
+        this.greatService = greatService;
+    }
+
+    @PostMapping("/great")
+    public SuccessResponse<?> greatAtBoard(@RequestParam("board-id") final Long boardId,
+                                           @Login final LoginMember loginMember) {
+        greatService.greatAtBoard(boardId, loginMember);
+
+        return SuccessResponse.of(GreatSuccess.GREAT_AT_BOARD_SUCCESS);
+    }
+
+    @GetMapping("/great/my-board")
+    public SuccessResponse<List<BoardResponse>> getAllGreatBoards(@Login final LoginMember loginMember,
+                                                                  @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+        return SuccessResponse.of(GreatSuccess.GET_ALL_GREAT_BOARDS_SUCCESS,
+                greatService.getGreatBoardPage(loginMember, pageable));
+    }
+}

--- a/src/main/java/com/aliens/backend/board/controller/MarketController.java
+++ b/src/main/java/com/aliens/backend/board/controller/MarketController.java
@@ -1,0 +1,67 @@
+package com.aliens.backend.board.controller;
+
+import com.aliens.backend.auth.controller.dto.LoginMember;
+import com.aliens.backend.board.controller.dto.request.MarketChangeRequest;
+import com.aliens.backend.board.controller.dto.request.MarketBoardCreateRequest;
+import com.aliens.backend.board.service.BoardReadService;
+import com.aliens.backend.board.service.BoardService;
+import com.aliens.backend.global.config.resolver.Login;
+import com.aliens.backend.global.response.SuccessResponse;
+import com.aliens.backend.global.response.success.MarketBoardSuccess;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RequestMapping("/boards/market")
+@RestController
+public class MarketController {
+
+    private final BoardService boardService;
+    private final BoardReadService boardReadService;
+
+    public MarketController(final BoardService boardService, final BoardReadService boardReadService) {
+        this.boardService = boardService;
+        this.boardReadService = boardReadService;
+    }
+
+    @PostMapping
+    public SuccessResponse<?> createMarketBoard(@Login final LoginMember loginMember,
+                                  @RequestBody final MarketBoardCreateRequest request,
+                                  @RequestPart final List<MultipartFile> marketBoardImages) {
+        boardService.postMarketBoard(request, marketBoardImages, loginMember);
+
+        return SuccessResponse.of(MarketBoardSuccess.CREATE_MARKET_BOARD_SUCCESS);
+    }
+
+    @GetMapping
+    public SuccessResponse<?> getMarketBoardPage(@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+        return SuccessResponse.of(MarketBoardSuccess.GET_MARKET_BOARD_PAGE_SUCCESS,
+                boardReadService.getMarketBoardPage(pageable));
+    }
+
+    @GetMapping("/details")
+    public SuccessResponse<?> getMarketBoardDetails(@RequestParam("id") final Long id) {
+        return SuccessResponse.of(MarketBoardSuccess.GET_MARKET_BOARD_DETAILS_SUCCESS,
+                boardReadService.getMarketBoardDetails(id));
+    }
+
+    @GetMapping("/search")
+    public SuccessResponse<?> searchMarketBoards(@RequestParam("search-keyword") final String searchKeyword,
+                                                     @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+        return SuccessResponse.of(MarketBoardSuccess.SEARCH_MARKET_BOARD_SUCCESS,
+                boardReadService.searchMarketBoardPage(searchKeyword, pageable));
+    }
+
+    @PutMapping
+    public SuccessResponse<?> changeMarketBoard(@Login final LoginMember loginMember,
+                                             @RequestParam("id") final Long boardId,
+                                             @RequestBody final MarketChangeRequest request) {
+        boardService.changeMarketBoard(boardId, request, loginMember);
+
+        return SuccessResponse.of(MarketBoardSuccess.CHANGE_MARKET_BOARD_SUCCESS);
+    }
+}

--- a/src/main/java/com/aliens/backend/board/controller/ReportController.java
+++ b/src/main/java/com/aliens/backend/board/controller/ReportController.java
@@ -1,0 +1,31 @@
+package com.aliens.backend.board.controller;
+
+import com.aliens.backend.auth.controller.dto.LoginMember;
+import com.aliens.backend.board.controller.dto.request.BoardCreateRequest;
+import com.aliens.backend.board.controller.dto.request.ReportBoardRequest;
+import com.aliens.backend.board.service.BoardReportService;
+import com.aliens.backend.chat.service.ChatReportService;
+import com.aliens.backend.global.config.resolver.Login;
+import com.aliens.backend.global.response.SuccessResponse;
+import com.aliens.backend.global.response.success.ReportSuccess;
+import org.springframework.web.bind.annotation.*;
+
+
+@RequestMapping("/reports")
+@RestController
+public class ReportController {
+
+    private final BoardReportService boardReportService;
+
+    public ReportController(final ChatReportService chatReportService,
+                            final BoardReportService boardReportService) {
+        this.boardReportService = boardReportService;
+    }
+
+    @PostMapping("/board")
+    public SuccessResponse<?> reportBoard(@Login final LoginMember loginMember,
+                                          @RequestBody final ReportBoardRequest request) {
+        boardReportService.report(loginMember, request);
+        return SuccessResponse.of(ReportSuccess.REPORT_BOARD_SUCCESS);
+    }
+}

--- a/src/main/java/com/aliens/backend/board/controller/dto/request/BoardCreateRequest.java
+++ b/src/main/java/com/aliens/backend/board/controller/dto/request/BoardCreateRequest.java
@@ -1,0 +1,15 @@
+package com.aliens.backend.board.controller.dto.request;
+
+
+import com.aliens.backend.board.domain.enums.BoardCategory;
+
+public record BoardCreateRequest(
+        String title,
+        String content,
+        BoardCategory boardCategory) {
+    public static BoardCreateRequest from(final MarketBoardCreateRequest marketRequest) {
+        return new BoardCreateRequest(marketRequest.title(),
+                marketRequest.content(),
+                BoardCategory.MARKET);
+    }
+}

--- a/src/main/java/com/aliens/backend/board/controller/dto/request/ChildCommentCreateRequest.java
+++ b/src/main/java/com/aliens/backend/board/controller/dto/request/ChildCommentCreateRequest.java
@@ -1,0 +1,4 @@
+package com.aliens.backend.board.controller.dto.request;
+
+public record ChildCommentCreateRequest(Long boardId, String content, Long parentCommentId) {
+}

--- a/src/main/java/com/aliens/backend/board/controller/dto/request/MarketBoardCreateRequest.java
+++ b/src/main/java/com/aliens/backend/board/controller/dto/request/MarketBoardCreateRequest.java
@@ -1,0 +1,12 @@
+package com.aliens.backend.board.controller.dto.request;
+
+import com.aliens.backend.board.domain.enums.ProductStatus;
+import com.aliens.backend.board.domain.enums.SaleStatus;
+
+public record MarketBoardCreateRequest(String title,
+                                       String content,
+                                       SaleStatus saleStatus,
+                                       String price,
+                                       ProductStatus productStatus
+                                       ) {
+}

--- a/src/main/java/com/aliens/backend/board/controller/dto/request/MarketChangeRequest.java
+++ b/src/main/java/com/aliens/backend/board/controller/dto/request/MarketChangeRequest.java
@@ -1,0 +1,12 @@
+package com.aliens.backend.board.controller.dto.request;
+
+import com.aliens.backend.board.domain.enums.ProductStatus;
+import com.aliens.backend.board.domain.enums.SaleStatus;
+
+public record MarketChangeRequest(
+        String title,
+        String content,
+        SaleStatus saleStatus,
+        String price,
+        ProductStatus productStatus) {
+}

--- a/src/main/java/com/aliens/backend/board/controller/dto/request/ParentCommentCreateRequest.java
+++ b/src/main/java/com/aliens/backend/board/controller/dto/request/ParentCommentCreateRequest.java
@@ -1,0 +1,5 @@
+package com.aliens.backend.board.controller.dto.request;
+
+public record ParentCommentCreateRequest(Long boardId,
+                                         String content) {
+}

--- a/src/main/java/com/aliens/backend/board/controller/dto/request/ReportBoardRequest.java
+++ b/src/main/java/com/aliens/backend/board/controller/dto/request/ReportBoardRequest.java
@@ -1,0 +1,5 @@
+package com.aliens.backend.board.controller.dto.request;
+
+public record ReportBoardRequest(Long boardId,
+                                 String reason) {
+}

--- a/src/main/java/com/aliens/backend/board/controller/dto/response/BoardResponse.java
+++ b/src/main/java/com/aliens/backend/board/controller/dto/response/BoardResponse.java
@@ -1,0 +1,31 @@
+package com.aliens.backend.board.controller.dto.response;
+
+import com.aliens.backend.board.domain.enums.BoardCategory;
+
+import java.time.Instant;
+import java.util.List;
+
+public record BoardResponse(Long id,
+        BoardCategory category,
+        String title,
+        String content,
+        Long greatCount,
+        Long commentCount,
+        List<String> imageUrls,
+        Instant createdAt,
+        MemberProfileDto memberProfileDto) {
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("\nid").append(id);
+        sb.append("\ncategory").append(category);
+        sb.append("\ntitle").append(title);
+        sb.append("\ncontent").append(content);
+        sb.append("\ngreatCount").append(greatCount);
+        sb.append("\ncommentCount").append(commentCount);
+        sb.append("\nimageUrls").append(imageUrls);
+        sb.append("\ncreatedAt").append(createdAt);
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/aliens/backend/board/controller/dto/response/CommentResponse.java
+++ b/src/main/java/com/aliens/backend/board/controller/dto/response/CommentResponse.java
@@ -1,0 +1,72 @@
+package com.aliens.backend.board.controller.dto.response;
+
+import com.aliens.backend.board.domain.enums.CommentStatus;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.time.Instant;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CommentResponse {
+    private final CommentStatus status;
+    private final Long id;
+    private final String content;
+    private final Instant createdAt;
+    private final MemberProfileDto memberProfileDto;
+    private List<CommentResponse> children;
+
+    public CommentResponse(CommentStatus status,
+                           Long id,
+                           String content,
+                           Instant createdAt,
+                           MemberProfileDto memberProfileDto) {
+        this.status = status;
+        this.id = id;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.memberProfileDto = memberProfileDto;
+    }
+
+    public CommentResponse(CommentStatus status,
+                           Long id,
+                           String content,
+                           Instant createdAt,
+                           MemberProfileDto memberProfileDto,
+                           List<CommentResponse> children) {
+        this.status = status;
+        this.id = id;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.memberProfileDto = memberProfileDto;
+        this.children = children;
+    }
+
+    public void setChildren(final List<CommentResponse> children) {
+        this.children = children;
+    }
+
+    public CommentStatus getStatus() {
+        return status;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public MemberProfileDto getMemberProfileDto() {
+        return memberProfileDto;
+    }
+
+    public List<CommentResponse> getChildren() {
+        return children;
+    }
+}
+

--- a/src/main/java/com/aliens/backend/board/controller/dto/response/MarketBoardResponse.java
+++ b/src/main/java/com/aliens/backend/board/controller/dto/response/MarketBoardResponse.java
@@ -1,0 +1,20 @@
+package com.aliens.backend.board.controller.dto.response;
+
+import com.aliens.backend.board.domain.enums.ProductStatus;
+import com.aliens.backend.board.domain.enums.SaleStatus;
+
+import java.time.Instant;
+import java.util.List;
+
+public record MarketBoardResponse(Long id,
+                                  String title,
+                                  SaleStatus saleStatus,
+                                  String price,
+                                  ProductStatus productStatus,
+                                  String content,
+                                  Long greatCount,
+                                  Long commentCount,
+                                  List<String>imageUrls,
+                                  Instant createdAt,
+                                  MemberProfileDto memberProfileDto) {
+}

--- a/src/main/java/com/aliens/backend/board/controller/dto/response/MemberProfileDto.java
+++ b/src/main/java/com/aliens/backend/board/controller/dto/response/MemberProfileDto.java
@@ -1,0 +1,6 @@
+package com.aliens.backend.board.controller.dto.response;
+
+public record MemberProfileDto( String name,
+                                String profileImageUrl,
+                                String nationality) {
+}

--- a/src/main/java/com/aliens/backend/board/domain/Board.java
+++ b/src/main/java/com/aliens/backend/board/domain/Board.java
@@ -1,0 +1,212 @@
+package com.aliens.backend.board.domain;
+
+import com.aliens.backend.auth.domain.Member;
+import com.aliens.backend.board.controller.dto.request.MarketChangeRequest;
+import com.aliens.backend.board.controller.dto.request.BoardCreateRequest;
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.controller.dto.response.MarketBoardResponse;
+import com.aliens.backend.board.domain.enums.BoardCategory;
+import jakarta.persistence.*;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Board {
+
+    @Id
+    @GeneratedValue(strategy =  GenerationType.IDENTITY)
+    @Column
+    private Long id;
+
+    @Column
+    private BoardCategory category;
+
+    @Column
+    private String title;
+
+    @Column
+    private String content;
+
+    @Column
+    private Long commentCount = 0L;
+
+    @Column
+    private Long greatCount = 0L;
+
+    @OneToMany(mappedBy = "board",
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
+            orphanRemoval = true)
+    private List<BoardImage> boardImages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "board",
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
+            orphanRemoval = true)
+    private List<Great> greats = new ArrayList<>();
+
+    @OneToMany(mappedBy = "board",
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
+            orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
+            orphanRemoval = true)
+    @JoinColumn(name = "market_info_id")
+    private MarketInfo marketInfo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(name = "created_at", updatable = false)
+    @CreatedDate
+    private Instant createdAt;
+
+    protected Board() {
+    }
+
+    private Board(
+            final String title,
+            final String content,
+            final BoardCategory category,
+            final Member member
+    ) {
+        this.title = title;
+        this.content = content;
+        this.category = category;
+        this.member = member;
+    }
+
+    public static Board normalOf(final BoardCreateRequest request,
+                                 final Member member) {
+        return new Board(
+                request.title(),
+                request.content(),
+                request.boardCategory(),
+                member
+                );
+    }
+
+    public static Board marketOf(final BoardCreateRequest request,
+                                 final Member member,
+                                 final MarketInfo marketInfo) {
+        return new Board(
+                request.title(),
+                request.content(),
+                request.boardCategory(),
+                member,
+                marketInfo
+                );
+    }
+
+    private Board(
+            final String title,
+            final String content,
+            final BoardCategory category,
+            final Member member,
+            final MarketInfo marketInfo
+    ) {
+        this.title = title;
+        this.content = content;
+        this.category = category;
+        this.member = member;
+        this.marketInfo = marketInfo;
+    }
+
+    public void update(
+            final String title,
+            final String content
+    ) {
+        this.title = title;
+        this.content = content;
+    }
+
+    public boolean isSameWithRequest(final BoardCreateRequest request) {
+        return this.title.equals(request.title())
+                && this.content.equals(request.content());
+    }
+
+    public boolean isSameWithRequest(final MarketChangeRequest request) {
+        return this.title.equals(request.title())
+                && this.content.equals(request.content());
+    }
+
+    public List<BoardImage> getImages() {
+        return boardImages;
+    }
+
+    public String getPrice() {
+        return marketInfo.getPrice();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setImages(final List<BoardImage> boardImageEntitys) {
+        this.boardImages.addAll(boardImageEntitys);
+    }
+
+    public void addComment(final Comment comment) {
+        commentCount++;
+        comments.add(comment);
+    }
+
+    public void addGreat(final Great great) {
+        greatCount++;
+        greats.add(great);
+    }
+
+    public BoardResponse getBoardResponse() {
+        return new BoardResponse(id,
+                category,
+                title,
+                content,
+                greatCount,
+                commentCount,
+                getImageURLs(),
+                createdAt,
+                member.getprofileDto());
+    }
+
+    private List<String> getImageURLs() {
+        return boardImages.stream().map(BoardImage::getURL).toList();
+    }
+
+    public MarketBoardResponse getMarketBoardResponse() {
+        return new MarketBoardResponse(
+                id,
+                title,
+                marketInfo.getSaleStatus(),
+                marketInfo.getPrice(),
+                marketInfo.getProductStatus(),
+                content,
+                greatCount,
+                commentCount,
+                getImageURLs(),
+                createdAt,
+                member.getprofileDto());
+    }
+
+    public boolean isWriter(final Long memberId) {
+        return member.isSameId(memberId);
+    }
+
+    public void changeByRequest(final MarketChangeRequest request) {
+        title = request.title();
+        content = request.content();
+        marketInfo.changePrice(request.price());
+        marketInfo.changeSaleStatus(request.saleStatus());
+        marketInfo.changeProductStatus(request.productStatus());
+    }
+
+    public void minusGreatCount() {
+        greatCount--;
+    }
+
+    public Long getGreatCount() {
+        return greatCount;
+    }
+}

--- a/src/main/java/com/aliens/backend/board/domain/BoardImage.java
+++ b/src/main/java/com/aliens/backend/board/domain/BoardImage.java
@@ -1,0 +1,44 @@
+package com.aliens.backend.board.domain;
+
+import com.aliens.backend.uploader.dto.S3File;
+import jakarta.persistence.*;
+
+@Entity
+public class BoardImage {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private Long id;
+
+    @Column
+    String name;
+
+    @Column
+    String url;
+
+    public void setBoard(final Board board) {
+        this.board = board;
+    }
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    protected BoardImage() {
+    }
+
+    public static BoardImage from(final S3File imageFile) {
+        BoardImage boardImage = new BoardImage();
+        boardImage.name = imageFile.fileName();
+        boardImage.url = imageFile.fileURL();
+        return boardImage;
+    }
+
+    public String getURL() {
+        return url;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/aliens/backend/board/domain/BoardReport.java
+++ b/src/main/java/com/aliens/backend/board/domain/BoardReport.java
@@ -1,0 +1,41 @@
+package com.aliens.backend.board.domain;
+
+import com.aliens.backend.auth.domain.Member;
+import com.aliens.backend.board.controller.dto.request.ReportBoardRequest;
+import jakarta.persistence.*;
+
+@Entity
+public class BoardReport {
+    @Id
+    @GeneratedValue(strategy =  GenerationType.IDENTITY)
+    @Column
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "reporting_member_id")
+    private Member member;
+
+    @Column
+    private Long boardId;
+
+    @Column
+    private String reason;
+
+    protected BoardReport() {
+    }
+
+    private BoardReport(Member member,
+                        Long boardId,
+                        String reason) {
+        this.member = member;
+        this.boardId = boardId;
+        this.reason = reason;
+    }
+
+    public static BoardReport of(final Member member, final ReportBoardRequest request) {
+        return new BoardReport(member,
+                request.boardId(),
+                request.reason());
+    }
+}
+

--- a/src/main/java/com/aliens/backend/board/domain/Comment.java
+++ b/src/main/java/com/aliens/backend/board/domain/Comment.java
@@ -1,0 +1,136 @@
+package com.aliens.backend.board.domain;
+
+import com.aliens.backend.auth.domain.Member;
+import com.aliens.backend.board.controller.dto.response.CommentResponse;
+import com.aliens.backend.board.controller.dto.request.ChildCommentCreateRequest;
+import com.aliens.backend.board.domain.enums.CommentStatus;
+import com.aliens.backend.board.domain.enums.CommentType;
+import jakarta.persistence.*;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.Instant;
+
+@Entity
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy =  GenerationType.IDENTITY)
+    @Column
+    private Long id;
+
+    @Column
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private CommentType type = CommentType.PARENT;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private CommentStatus status = CommentStatus.ACTIVE;
+
+    @Column
+    private Long parentCommentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(name = "created_at", updatable = false)
+    @CreatedDate
+    private Instant createdAt;
+
+    protected Comment() {
+    }
+
+    private Comment(
+            final String content,
+            final Board board,
+            final Member member
+    ) {
+        this.content = content;
+        this.board = board;
+        this.member = member;
+    }
+
+    public static Comment parentOf(
+            final String content,
+            final Board board,
+            final Member member
+    ) {
+        return new Comment(
+                content,
+                board,
+                member
+        );
+    }
+
+    private Comment(
+            final String content,
+            final CommentType type,
+            final Board board,
+            final Long parentCommentId,
+            final Member member
+    ) {
+        this.content = content;
+        this.type = type;
+        this.board = board;
+        this.parentCommentId = parentCommentId;
+        this.member = member;
+    }
+
+    public static Comment childOf(
+            final ChildCommentCreateRequest request,
+            final Board board,
+            final Member member
+    ) {
+        return new Comment(
+                request.content(),
+                CommentType.CHILD,
+                board,
+                request.parentCommentId(),
+                member
+        );
+    }
+
+    public void deleteComment() {
+        this.status = CommentStatus.DELETE;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public boolean isParent() {
+        return type == CommentType.PARENT;
+    }
+
+    public CommentResponse getCommentResponse() {
+        return new CommentResponse(
+                status,
+                id,
+                content,
+                createdAt,
+                member.getprofileDto());
+    }
+
+    public boolean isChildFrom(final Long id) {
+        return parentCommentId != null && parentCommentId.equals(id);
+    }
+
+    public boolean isWriter(final Long memberId) {
+        return member.isSameId(memberId);
+    }
+
+    public CommentStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/aliens/backend/board/domain/Great.java
+++ b/src/main/java/com/aliens/backend/board/domain/Great.java
@@ -1,0 +1,31 @@
+package com.aliens.backend.board.domain;
+
+import com.aliens.backend.auth.domain.Member;
+import jakarta.persistence.*;
+
+@Entity
+public class Great {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    protected Great() {
+    }
+
+    public static Great of(final Board board,
+                           final Member member) {
+        Great great = new Great();
+        great.board = board;
+        great.member = member;
+        return great;
+    }
+}

--- a/src/main/java/com/aliens/backend/board/domain/MarketInfo.java
+++ b/src/main/java/com/aliens/backend/board/domain/MarketInfo.java
@@ -1,0 +1,69 @@
+package com.aliens.backend.board.domain;
+
+import com.aliens.backend.board.controller.dto.request.MarketBoardCreateRequest;
+import com.aliens.backend.board.domain.enums.ProductStatus;
+import com.aliens.backend.board.domain.enums.SaleStatus;
+import jakarta.persistence.*;
+
+@Entity
+public class MarketInfo {
+
+    @Id
+    @GeneratedValue(strategy =  GenerationType.IDENTITY)
+    @Column
+    private Long id;
+
+    @Column
+    private String price;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private SaleStatus saleStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column
+    private ProductStatus productStatus;
+
+    protected MarketInfo() {
+    }
+
+    public MarketInfo(final String price,
+                      final SaleStatus saleStatus,
+                      final ProductStatus productStatus) {
+        this.price = price;
+        this.saleStatus = saleStatus;
+        this.productStatus = productStatus;
+    }
+
+    public static MarketInfo from(final MarketBoardCreateRequest request) {
+        return new MarketInfo(
+                request.price(),
+                request.saleStatus(),
+                request.productStatus()
+        );
+    }
+
+    public String getPrice() {
+        return price;
+    }
+
+    public SaleStatus getSaleStatus() {
+        return saleStatus;
+    }
+
+    public ProductStatus getProductStatus() {
+        return productStatus;
+    }
+
+    public void changePrice(final String price) {
+        this.price = price;
+    }
+
+    public void changeSaleStatus(final SaleStatus status) {
+        this.saleStatus = status;
+    }
+
+    public void changeProductStatus(final ProductStatus status) {
+        this.productStatus = status;
+    }
+}

--- a/src/main/java/com/aliens/backend/board/domain/enums/BoardCategory.java
+++ b/src/main/java/com/aliens/backend/board/domain/enums/BoardCategory.java
@@ -1,0 +1,34 @@
+package com.aliens.backend.board.domain.enums;
+
+public enum BoardCategory {
+
+    ALL("all", "전체게시판"),
+    MARKET("market", "장터게시판"),
+    FREE("free", "자유게시판"),
+    INFO("info", "정보게시판"),
+    MUSIC("music", "음악게시판"),
+    GAME("game", "게임게시판"),
+    FOOD("food", "음식게시판"),
+    FASHION("fashion", "패션게시판"),
+    ANNOUNCEMENT("announcement", "공지사항");
+
+    private String value;
+    private String name;
+
+    BoardCategory(final String value, final String name) {
+        this.value = value;
+        this.name = name;
+    }
+
+    public static BoardCategory from(final String request) {
+        if (request == null) {
+            return ALL;
+        }
+
+        for (BoardCategory category : BoardCategory.values()) {
+            if (category.value.equals(request)) return category;
+        }
+
+        throw new IllegalArgumentException("일치하는 카테고리 없음");
+    }
+}

--- a/src/main/java/com/aliens/backend/board/domain/enums/CommentStatus.java
+++ b/src/main/java/com/aliens/backend/board/domain/enums/CommentStatus.java
@@ -1,0 +1,5 @@
+package com.aliens.backend.board.domain.enums;
+
+public enum CommentStatus {
+    ACTIVE, DELETE
+}

--- a/src/main/java/com/aliens/backend/board/domain/enums/CommentType.java
+++ b/src/main/java/com/aliens/backend/board/domain/enums/CommentType.java
@@ -1,0 +1,5 @@
+package com.aliens.backend.board.domain.enums;
+
+public enum CommentType {
+    PARENT, CHILD
+}

--- a/src/main/java/com/aliens/backend/board/domain/enums/ProductStatus.java
+++ b/src/main/java/com/aliens/backend/board/domain/enums/ProductStatus.java
@@ -1,0 +1,31 @@
+package com.aliens.backend.board.domain.enums;
+
+public enum ProductStatus {
+    BRAND_NEW("새 것"),
+    ALMOST_NEW("거의 새 것"),
+    SLIGHT_DEFECT("약간의 하자"),
+    USED("사용감 있음");
+
+    private final String value;
+
+    ProductStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static ProductStatus of(String value) {
+        for (ProductStatus status : ProductStatus.values()) {
+            if (status.value.equals(value)) {
+                return status;
+            }
+            if (status.name().equalsIgnoreCase(value)) {
+                return status;
+            }
+        }
+
+        throw new IllegalArgumentException("일치하는 상품상태 없음");
+    }
+}

--- a/src/main/java/com/aliens/backend/board/domain/enums/SaleStatus.java
+++ b/src/main/java/com/aliens/backend/board/domain/enums/SaleStatus.java
@@ -1,0 +1,30 @@
+package com.aliens.backend.board.domain.enums;
+
+
+public enum SaleStatus {
+    SELL("판매 중"),
+    END("판매 완료");
+
+    private final String value;
+
+    SaleStatus(final String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static SaleStatus of(String value) {
+        for (SaleStatus status : SaleStatus.values()) {
+            if (status.value.equals(value)) {
+                return status;
+            }
+            if (status.name().equalsIgnoreCase(value)) {
+                return status;
+            }
+        }
+
+        throw new IllegalArgumentException("일치하는 판매상태 없음");
+    }
+}

--- a/src/main/java/com/aliens/backend/board/domain/repository/BoardImageRepository.java
+++ b/src/main/java/com/aliens/backend/board/domain/repository/BoardImageRepository.java
@@ -1,0 +1,9 @@
+package com.aliens.backend.board.domain.repository;
+
+import com.aliens.backend.board.domain.BoardImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoardImageRepository  extends JpaRepository<BoardImage, Long>  {
+}

--- a/src/main/java/com/aliens/backend/board/domain/repository/BoardReportRepository.java
+++ b/src/main/java/com/aliens/backend/board/domain/repository/BoardReportRepository.java
@@ -1,0 +1,8 @@
+package com.aliens.backend.board.domain.repository;
+
+import com.aliens.backend.board.domain.BoardReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardReportRepository extends JpaRepository<BoardReport, Long> {
+    Long countByBoardId(Long boardId);
+}

--- a/src/main/java/com/aliens/backend/board/domain/repository/BoardReportRepository.java
+++ b/src/main/java/com/aliens/backend/board/domain/repository/BoardReportRepository.java
@@ -2,7 +2,9 @@ package com.aliens.backend.board.domain.repository;
 
 import com.aliens.backend.board.domain.BoardReport;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface BoardReportRepository extends JpaRepository<BoardReport, Long> {
     Long countByBoardId(Long boardId);
 }

--- a/src/main/java/com/aliens/backend/board/domain/repository/BoardRepository.java
+++ b/src/main/java/com/aliens/backend/board/domain/repository/BoardRepository.java
@@ -1,0 +1,18 @@
+package com.aliens.backend.board.domain.repository;
+
+import com.aliens.backend.board.domain.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BoardRepository extends JpaRepository<Board,Long> {
+
+    @Query("SELECT b FROM Board b LEFT JOIN FETCH b.marketInfo LEFT JOIN FETCH b.boardImages")
+    List<Board> findAlLWithMarketInfo();
+
+    @Query("SELECT b FROM Board b LEFT JOIN FETCH b.boardImages")
+    List<Board> findAllWithBoardImage();
+}

--- a/src/main/java/com/aliens/backend/board/domain/repository/CommentRepository.java
+++ b/src/main/java/com/aliens/backend/board/domain/repository/CommentRepository.java
@@ -1,0 +1,12 @@
+package com.aliens.backend.board.domain.repository;
+
+import com.aliens.backend.board.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment,Long> {
+//    Optional<Comment> findById(final Long id);
+}

--- a/src/main/java/com/aliens/backend/board/domain/repository/GreatRepository.java
+++ b/src/main/java/com/aliens/backend/board/domain/repository/GreatRepository.java
@@ -1,0 +1,19 @@
+package com.aliens.backend.board.domain.repository;
+
+
+import com.aliens.backend.auth.domain.Member;
+import com.aliens.backend.board.domain.Board;
+import com.aliens.backend.board.domain.Great;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface GreatRepository extends JpaRepository<Great,Long> {
+    long deleteGreatByMemberAndBoard(Member member, Board board);
+
+    Optional<Great> findByMemberAndBoard(Member member, Board board);
+
+    boolean existsByMemberAndBoard(Member member, Board board);
+}

--- a/src/main/java/com/aliens/backend/board/domain/repository/MarketInfoRepository.java
+++ b/src/main/java/com/aliens/backend/board/domain/repository/MarketInfoRepository.java
@@ -1,0 +1,9 @@
+package com.aliens.backend.board.domain.repository;
+
+import com.aliens.backend.board.domain.MarketInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MarketInfoRepository extends JpaRepository<MarketInfo,Long> {
+}

--- a/src/main/java/com/aliens/backend/board/domain/repository/custom/BoardCustomRepository.java
+++ b/src/main/java/com/aliens/backend/board/domain/repository/custom/BoardCustomRepository.java
@@ -1,0 +1,20 @@
+package com.aliens.backend.board.domain.repository.custom;
+
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.controller.dto.response.MarketBoardResponse;
+import com.aliens.backend.board.domain.enums.BoardCategory;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+
+public interface BoardCustomRepository {
+    List<BoardResponse> getBoardPage(Pageable pageable);
+    List<BoardResponse> getMyBoardPage(Long memberId, Pageable pageable);
+    List<BoardResponse> getBoardPageWithCategory(BoardCategory boardCategory, Pageable pageable);
+    List<MarketBoardResponse> getMarketBoardPage(Pageable pageable);
+
+    List<BoardResponse> searchBoardPageWithKeyword(String keyword, Pageable pageable);
+    List<MarketBoardResponse> searchMarketBoardPage(String keyword, Pageable pageable);
+    List<BoardResponse> searchBoardPageWithKeywordAndCategory(String searchKeyword, BoardCategory boardCategory, Pageable pageable);
+}

--- a/src/main/java/com/aliens/backend/board/domain/repository/custom/BoardCustomRepositoryImpl.java
+++ b/src/main/java/com/aliens/backend/board/domain/repository/custom/BoardCustomRepositoryImpl.java
@@ -1,0 +1,195 @@
+package com.aliens.backend.board.domain.repository.custom;
+
+import com.aliens.backend.auth.domain.QMember;
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.controller.dto.response.MarketBoardResponse;
+import com.aliens.backend.board.domain.*;
+import com.aliens.backend.board.domain.enums.BoardCategory;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional(readOnly = true)
+@Repository
+public class BoardCustomRepositoryImpl implements BoardCustomRepository {
+    private final JPAQueryFactory queryFactory;
+    private final QBoard qBoard = QBoard.board;
+    private final QMember qMember = QMember.member;
+
+    public BoardCustomRepositoryImpl(final JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public List<BoardResponse> getBoardPage(final Pageable pageable) {
+        List<Tuple> results = queryFactory
+                .select(qBoard, qMember, qMember.memberImage)
+                .from(qBoard)
+                .leftJoin(qBoard.boardImages).fetchJoin()
+                .leftJoin(qBoard.member, qMember).fetchJoin()
+                .leftJoin(qMember.memberImage)
+
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch()
+                .stream().distinct().toList();
+
+        return results.stream()
+                .map(tuple -> {
+                    Board board = tuple.get(qBoard);
+                    return board.getBoardResponse();
+                })
+                .toList();
+    }
+
+    @Override
+    public List<BoardResponse> getBoardPageWithCategory(final BoardCategory category, Pageable pageable) {
+        List<Tuple> results = queryFactory
+                .select(qBoard, qMember, qMember.memberImage)
+                .from(qBoard)
+                .leftJoin(qBoard.boardImages).fetchJoin()
+                .leftJoin(qBoard.member, qMember).fetchJoin()
+                .leftJoin(qMember.memberImage)
+
+                .where(qBoard.category.eq(category))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch()
+                .stream().distinct().toList();
+
+        return results.stream()
+                .map(tuple -> {
+                    Board board = tuple.get(qBoard);
+                    return board.getBoardResponse();
+                })
+                .toList();
+    }
+
+    @Override
+    public List<BoardResponse> searchBoardPageWithKeyword(final String keyword, final Pageable pageable) {
+        List<Tuple> results = queryFactory
+                .select(qBoard, qMember, qMember.memberImage)
+                .from(qBoard)
+                .leftJoin(qBoard.boardImages).fetchJoin()
+                .leftJoin(qBoard.member, qMember).fetchJoin()
+                .leftJoin(qMember.memberImage)
+                .where(qBoard.title.likeIgnoreCase("%" + keyword + "%")
+                        .or(qBoard.content.likeIgnoreCase("%" + keyword + "%")))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch()
+                .stream().distinct().toList();
+
+
+        return results.stream()
+                .map(tuple -> {
+                    Board board = tuple.get(qBoard);
+                    return board.getBoardResponse();
+                })
+                .toList();
+    }
+
+    @Override
+    public List<MarketBoardResponse> getMarketBoardPage(final Pageable pageable) {
+        List<Tuple> results = queryFactory
+                .select(qBoard, qBoard.marketInfo, qMember, qMember.memberImage)
+                .from(qBoard)
+                .leftJoin(qBoard.boardImages).fetchJoin()
+                .leftJoin(qBoard.member, qMember).fetchJoin()
+                .leftJoin(qMember.memberImage)
+                .where(qBoard.category.eq(BoardCategory.MARKET))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch()
+                .stream().distinct().toList();
+
+
+        return results.stream()
+                .map(tuple -> {
+                    Board board = tuple.get(qBoard);
+                    return board.getMarketBoardResponse();
+                })
+                .toList();
+    }
+
+    @Override
+    public List<MarketBoardResponse> searchMarketBoardPage(final String keyword, final Pageable pageable) {
+        List<Tuple> results = queryFactory
+                .select(qBoard, qBoard.marketInfo, qMember, qMember.memberImage)
+                .from(qBoard)
+                .leftJoin(qBoard.boardImages).fetchJoin()
+                .leftJoin(qBoard.member, qMember).fetchJoin()
+                .leftJoin(qMember.memberImage)
+                .where(qBoard.category.eq(BoardCategory.MARKET)
+                        .and(qBoard.title.likeIgnoreCase("%" + keyword + "%")
+                                .or((qBoard.content.likeIgnoreCase("%" + keyword + "%")))))
+
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch()
+                .stream().distinct().toList();
+
+
+        return results.stream()
+                .map(tuple -> {
+                    Board board = tuple.get(qBoard);
+                    return board.getMarketBoardResponse();
+                })
+                .toList();
+    }
+
+    @Override
+    public List<BoardResponse> getMyBoardPage(Long memberId, Pageable pageable) {
+        List<Tuple> results = queryFactory
+                .select(qBoard, qBoard.marketInfo, qMember, qMember.memberImage)
+                .from(qBoard)
+                .leftJoin(qBoard.boardImages).fetchJoin()
+                .leftJoin(qBoard.member, qMember).fetchJoin()
+                .leftJoin(qMember.memberImage)
+                .where(qBoard.member.id.eq(memberId))
+
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch()
+                .stream().distinct().toList();
+
+
+        return results.stream()
+                .map(tuple -> {
+                    Board board = tuple.get(qBoard);
+                    return board.getBoardResponse();
+                })
+                .toList();
+    }
+
+    public List<BoardResponse> searchBoardPageWithKeywordAndCategory(String keyword,
+                                                                     BoardCategory category,
+                                                                     Pageable pageable) {
+        List<Tuple> results = queryFactory
+                .select(qBoard, qBoard.marketInfo, qMember, qMember.memberImage)
+                .from(qBoard)
+                .leftJoin(qBoard.boardImages).fetchJoin()
+                .leftJoin(qBoard.member, qMember).fetchJoin()
+                .leftJoin(qMember.memberImage)
+                .where(qBoard.category.eq(category)
+                        .and(qBoard.title.likeIgnoreCase("%" + keyword + "%")
+                                .or((qBoard.content.likeIgnoreCase("%" + keyword + "%")))))
+
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch()
+                .stream().distinct().toList();
+
+
+        return results.stream()
+                .map(tuple -> {
+                    Board board = tuple.get(qBoard);
+                    return board.getBoardResponse();
+                })
+                .toList();
+    }
+}

--- a/src/main/java/com/aliens/backend/board/domain/repository/custom/CommentCustomRepository.java
+++ b/src/main/java/com/aliens/backend/board/domain/repository/custom/CommentCustomRepository.java
@@ -1,0 +1,13 @@
+package com.aliens.backend.board.domain.repository.custom;
+
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.domain.Comment;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface CommentCustomRepository {
+    List<BoardResponse> getCommentedBoardPage(final Long memberId, final Pageable pageable);
+
+    List<Comment> getCommentsByBoardId(final Long boardId);
+}

--- a/src/main/java/com/aliens/backend/board/domain/repository/custom/CommentCustomRepositoryImpl.java
+++ b/src/main/java/com/aliens/backend/board/domain/repository/custom/CommentCustomRepositoryImpl.java
@@ -1,0 +1,67 @@
+package com.aliens.backend.board.domain.repository.custom;
+
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.domain.*;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional(readOnly = true)
+@Repository
+public class CommentCustomRepositoryImpl implements CommentCustomRepository {
+    private final JPAQueryFactory queryFactory;
+    private final QBoard qBoard = QBoard.board;
+    private final QComment qComment = QComment.comment;
+
+    public CommentCustomRepositoryImpl(final JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public List<BoardResponse> getCommentedBoardPage(final Long memberId, final Pageable pageable) {
+        List<Tuple> results = queryFactory
+                .select(qBoard, qBoard.member.memberImage)
+                .from(qComment)
+                .join(qComment.board, qBoard)
+                .leftJoin(qBoard.boardImages).fetchJoin()
+                .leftJoin(qBoard.member).fetchJoin()
+                .leftJoin(qBoard.member.memberImage)
+
+                .where(qComment.member.id.eq(memberId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch()
+                .stream().distinct().toList();
+
+
+        return results.stream()
+                .map(tuple -> {
+                    Board board = tuple.get(qBoard);
+                    return board.getBoardResponse();
+                })
+                .toList();
+    }
+
+    @Override
+    public List<Comment> getCommentsByBoardId(final Long boardId) {
+        List<Tuple> results = queryFactory
+                .select(qComment, qComment.member.memberImage)
+                .from(qComment)
+                .leftJoin(qComment.member).fetchJoin()
+                .leftJoin(qComment.member.memberImage)
+
+                .where(qComment.board.id.eq(boardId))
+                .fetch()
+                .stream().distinct().toList();
+
+
+        return results.stream()
+                .map(tuple -> tuple.get(qComment))
+                .toList();
+    }
+}
+

--- a/src/main/java/com/aliens/backend/board/domain/repository/custom/GreatCustomRepository.java
+++ b/src/main/java/com/aliens/backend/board/domain/repository/custom/GreatCustomRepository.java
@@ -1,0 +1,10 @@
+package com.aliens.backend.board.domain.repository.custom;
+
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface GreatCustomRepository {
+    List<BoardResponse> getGreatBoardPage(final Long memberId, final Pageable pageable);
+}

--- a/src/main/java/com/aliens/backend/board/domain/repository/custom/GreatCustomRepositoryImpl.java
+++ b/src/main/java/com/aliens/backend/board/domain/repository/custom/GreatCustomRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.aliens.backend.board.domain.repository.custom;
+
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.domain.*;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional(readOnly = true)
+@Repository
+public class GreatCustomRepositoryImpl implements GreatCustomRepository {
+    private final JPAQueryFactory queryFactory;
+    private final QBoard qBoard = QBoard.board;
+    private final QGreat qGreat = QGreat.great;
+
+    public GreatCustomRepositoryImpl(final JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public List<BoardResponse> getGreatBoardPage(final Long memberId, final Pageable pageable) {
+        List<Tuple> results = queryFactory
+                .select(qBoard, qBoard.member.memberImage)
+                .from(qGreat)
+
+                .join(qGreat.board, qBoard)
+                .leftJoin(qBoard.boardImages).fetchJoin()
+                .leftJoin(qBoard.member).fetchJoin()
+                .leftJoin(qBoard.member.memberImage)
+
+                .where(qGreat.member.id.eq(memberId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch()
+                .stream().distinct().toList();
+
+
+        return results.stream()
+                .map(tuple -> {
+                    Board board = tuple.get(qBoard);
+                    return board.getBoardResponse();
+                })
+                .toList();
+    }
+}
+

--- a/src/main/java/com/aliens/backend/board/service/BoardReadService.java
+++ b/src/main/java/com/aliens/backend/board/service/BoardReadService.java
@@ -1,0 +1,74 @@
+package com.aliens.backend.board.service;
+
+import com.aliens.backend.auth.controller.dto.LoginMember;
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.controller.dto.response.MarketBoardResponse;
+import com.aliens.backend.board.domain.Board;
+import com.aliens.backend.board.domain.enums.BoardCategory;
+import com.aliens.backend.board.domain.repository.BoardRepository;
+import com.aliens.backend.board.domain.repository.custom.BoardCustomRepository;
+import com.aliens.backend.global.exception.RestApiException;
+import com.aliens.backend.global.response.error.BoardError;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional(readOnly = true)
+@Service
+public class BoardReadService {
+
+    private final BoardCustomRepository boardCustomRepository;
+    private final BoardRepository boardRepository;
+
+    public BoardReadService(final BoardCustomRepository boardCustomRepository,
+                            final BoardRepository boardRepository) {
+        this.boardCustomRepository = boardCustomRepository;
+        this.boardRepository = boardRepository;
+    }
+
+    public List<BoardResponse> getBoardPage(final Pageable pageable) {
+        return boardCustomRepository.getBoardPage(pageable);
+    }
+
+    public List<BoardResponse> getBoardPageWithCategory(String category, final Pageable pageable) {
+        BoardCategory boardCategory = BoardCategory.from(category);
+        return boardCustomRepository.getBoardPageWithCategory(boardCategory, pageable);
+    }
+
+    public List<BoardResponse> searchBoardPageWithKeyword(final String searchKeyword, final Pageable pageable) {
+        return boardCustomRepository.searchBoardPageWithKeyword(searchKeyword, pageable);
+    }
+
+    public List<BoardResponse> getAnnouncePage(final Pageable pageable) {
+        BoardCategory boardCategory = BoardCategory.ANNOUNCEMENT;
+        return boardCustomRepository.getBoardPageWithCategory(boardCategory, pageable);
+    }
+
+    public List<MarketBoardResponse> getMarketBoardPage(final Pageable pageable) {
+        return boardCustomRepository.getMarketBoardPage(pageable);
+    }
+
+    public MarketBoardResponse getMarketBoardDetails(final Long id) {
+        Board board = getBoard(id);
+        return board.getMarketBoardResponse();
+    }
+
+    private Board getBoard(final Long id) {
+        return boardRepository.findById(id).orElseThrow(() -> new RestApiException(BoardError.INVALID_BOARD_ID));
+    }
+
+    public List<MarketBoardResponse> searchMarketBoardPage(final String searchKeyword, final Pageable pageable) {
+        return boardCustomRepository.searchMarketBoardPage(searchKeyword, pageable);
+    }
+
+    public List<BoardResponse> getMyBoardPage(final LoginMember loginMember, final Pageable pageable) {
+        return boardCustomRepository.getMyBoardPage(loginMember.memberId(), pageable);
+    }
+
+    public List<BoardResponse> searchBoardPageWithKeywordAndCategory(final String searchKeyword, final String category, final Pageable pageable) {
+        BoardCategory boardCategory = BoardCategory.from(category);
+        return boardCustomRepository.searchBoardPageWithKeywordAndCategory(searchKeyword, boardCategory, pageable);
+    }
+}

--- a/src/main/java/com/aliens/backend/board/service/BoardReportService.java
+++ b/src/main/java/com/aliens/backend/board/service/BoardReportService.java
@@ -1,0 +1,53 @@
+package com.aliens.backend.board.service;
+
+import com.aliens.backend.auth.controller.dto.LoginMember;
+import com.aliens.backend.auth.domain.Member;
+import com.aliens.backend.auth.domain.repository.MemberRepository;
+import com.aliens.backend.board.controller.dto.request.ReportBoardRequest;
+import com.aliens.backend.board.domain.Board;
+import com.aliens.backend.board.domain.BoardReport;
+import com.aliens.backend.board.domain.repository.BoardReportRepository;
+import com.aliens.backend.board.domain.repository.BoardRepository;
+import com.aliens.backend.global.exception.RestApiException;
+import com.aliens.backend.global.response.error.BoardError;
+import com.aliens.backend.global.response.error.MemberError;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class BoardReportService {
+
+    private final BoardReportRepository boardReportRepository;
+    private final BoardRepository boardRepository;
+    private final MemberRepository memberRepository;
+
+    public BoardReportService(final BoardReportRepository boardReportRepository,
+                              final BoardRepository boardRepository,
+                              final MemberRepository memberRepository) {
+        this.boardReportRepository = boardReportRepository;
+        this.boardRepository = boardRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public void report(final LoginMember loginMember, final ReportBoardRequest request) {
+        Member member = getMember(loginMember);
+
+        BoardReport boardReport = BoardReport.of(member, request);
+        boardReportRepository.save(boardReport);
+
+        if(boardReportRepository.countByBoardId(request.boardId()) >= 5) {
+            Board board = getBoardById(request.boardId());
+            boardRepository.delete(board);
+        }
+    }
+
+    private Member getMember(final LoginMember loginMember) {
+        return memberRepository.findById(loginMember.memberId()).orElseThrow(() -> new RestApiException(MemberError.NULL_MEMBER));
+    }
+
+    private Board getBoardById(final Long id) {
+        return boardRepository.findById(id).orElseThrow(() -> new RestApiException(BoardError.INVALID_BOARD_ID));
+    }
+
+}

--- a/src/main/java/com/aliens/backend/board/service/BoardService.java
+++ b/src/main/java/com/aliens/backend/board/service/BoardService.java
@@ -1,0 +1,121 @@
+package com.aliens.backend.board.service;
+
+import com.aliens.backend.auth.controller.dto.LoginMember;
+import com.aliens.backend.auth.domain.Member;
+import com.aliens.backend.auth.domain.repository.MemberRepository;
+import com.aliens.backend.board.controller.dto.request.MarketChangeRequest;
+import com.aliens.backend.board.controller.dto.request.BoardCreateRequest;
+import com.aliens.backend.board.controller.dto.request.MarketBoardCreateRequest;
+import com.aliens.backend.board.domain.Board;
+import com.aliens.backend.board.domain.BoardImage;
+import com.aliens.backend.board.domain.MarketInfo;
+import com.aliens.backend.board.domain.repository.BoardRepository;
+import com.aliens.backend.global.exception.RestApiException;
+import com.aliens.backend.global.response.error.BoardError;
+import com.aliens.backend.global.response.error.MemberError;
+import com.aliens.backend.uploader.AwsS3Uploader;
+import com.aliens.backend.uploader.dto.S3File;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class BoardService {
+    private final BoardRepository boardRepository;
+    private final AwsS3Uploader imageUploader;
+    private final MemberRepository memberRepository;
+
+    public BoardService(final BoardRepository boardRepository,
+                        final AwsS3Uploader imageUploader,
+                        final MemberRepository memberRepository) {
+        this.boardRepository = boardRepository;
+        this.imageUploader = imageUploader;
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public void postNormalBoard(final BoardCreateRequest request,
+                          final List<MultipartFile> boardImages,
+                          final LoginMember loginMember) {
+        Member member = getMember(loginMember);
+        Board board = Board.normalOf(request, member);
+
+        if(boardImages == null || boardImages.isEmpty()) {
+            boardRepository.save(board);
+            return;
+        }
+
+        List<BoardImage> boardImageEntitys = uploadS3(boardImages, board);
+        board.setImages(boardImageEntitys);
+        boardRepository.save(board);
+    }
+
+    private List<BoardImage> uploadS3(final List<MultipartFile> boardImages, final Board board) {
+        List<BoardImage> boardImageEntities = new ArrayList<>();
+        List<S3File> s3Files = imageUploader.multiUpload(boardImages);
+
+        for (S3File imageFile : s3Files) {
+            BoardImage boardImage = BoardImage.from(imageFile);
+            boardImage.setBoard(board); // BoardImage 엔티티에 Board 연관 설정
+            boardImageEntities.add(boardImage);
+        }
+        return boardImageEntities;
+    }
+
+    private Member getMember(final LoginMember loginMember) {
+        return memberRepository.findById(loginMember.memberId()).orElseThrow(() -> new RestApiException(MemberError.NULL_MEMBER));
+    }
+
+    @Transactional
+    public void postMarketBoard(final MarketBoardCreateRequest marketRequest,
+                                final List<MultipartFile> marketBoardImages,
+                                final LoginMember loginMember) {
+        Member member = getMember(loginMember);
+        BoardCreateRequest boardRequest = BoardCreateRequest.from(marketRequest);
+
+        MarketInfo marketInfo = MarketInfo.from(marketRequest);
+        Board board = Board.marketOf(boardRequest, member, marketInfo);
+
+        if(marketBoardImages == null ||marketBoardImages.isEmpty()) {
+            boardRepository.save(board);
+            return;
+        }
+
+        List<BoardImage> boardImageEntitys = uploadS3(marketBoardImages, board);
+        board.setImages(boardImageEntitys);
+        boardRepository.save(board);
+    }
+
+    private Board getBoardById(final Long id) {
+        return boardRepository.findById(id).orElseThrow(() -> new RestApiException(BoardError.INVALID_BOARD_ID));
+    }
+
+    @Transactional
+    public void changeMarketBoard(final Long boardId, final MarketChangeRequest request, final LoginMember loginMember) {
+        Board board = getBoardById(boardId);
+        if(!board.isWriter(loginMember.memberId())) {
+            throw new RestApiException(BoardError.NOT_WRITER);
+        }
+        board.changeByRequest(request);
+    }
+
+    @Transactional
+    public void deleteBoard(final LoginMember loginMember, final Long boardId) {
+        Board board = getBoardById(boardId);
+
+        if(!board.isWriter(loginMember.memberId())) {
+            throw new RestApiException(BoardError.NOT_WRITER);
+        }
+
+        deleteImageOnS3(board);
+        boardRepository.delete(board);
+    }
+
+    private void deleteImageOnS3(final Board board) {
+        List<BoardImage> images = board.getImages();
+        images.forEach(i -> imageUploader.delete(i.getName()));
+    }
+}

--- a/src/main/java/com/aliens/backend/board/service/CommentService.java
+++ b/src/main/java/com/aliens/backend/board/service/CommentService.java
@@ -1,0 +1,106 @@
+package com.aliens.backend.board.service;
+
+import com.aliens.backend.auth.controller.dto.LoginMember;
+import com.aliens.backend.auth.domain.Member;
+import com.aliens.backend.auth.domain.repository.MemberRepository;
+import com.aliens.backend.board.controller.dto.response.CommentResponse;
+import com.aliens.backend.board.controller.dto.request.ParentCommentCreateRequest;
+import com.aliens.backend.board.controller.dto.request.ChildCommentCreateRequest;
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.domain.Board;
+import com.aliens.backend.board.domain.Comment;
+import com.aliens.backend.board.domain.repository.BoardRepository;
+import com.aliens.backend.board.domain.repository.CommentRepository;
+import com.aliens.backend.board.domain.repository.custom.CommentCustomRepository;
+import com.aliens.backend.global.exception.RestApiException;
+import com.aliens.backend.global.response.error.BoardError;
+import com.aliens.backend.global.response.error.MemberError;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+    private final BoardRepository boardRepository;
+    private final CommentCustomRepository commentCustomRepository;
+
+    public CommentService(final CommentRepository commentRepository, final MemberRepository memberRepository, final BoardRepository boardRepository, final CommentCustomRepository commentCustomRepository) {
+        this.commentRepository = commentRepository;
+        this.memberRepository = memberRepository;
+        this.boardRepository = boardRepository;
+        this.commentCustomRepository = commentCustomRepository;
+    }
+
+    @Transactional
+    public void postParentComment(final ParentCommentCreateRequest request,
+                                  final LoginMember loginMember) {
+        Member member = getMember(loginMember);
+        Board board = findBoard(request.boardId());
+        Comment comment = Comment.parentOf(request.content(), board, member);
+        board.addComment(comment);
+
+        commentRepository.save(comment);
+    }
+
+    private Board findBoard(final Long boardId) {
+        return boardRepository.findById(boardId).orElseThrow(() -> new RestApiException(MemberError.NULL_MEMBER));
+    }
+
+    private Member getMember(final LoginMember loginMember) {
+        return memberRepository.findById(loginMember.memberId()).orElseThrow(() -> new RestApiException(MemberError.NULL_MEMBER));
+    }
+
+    @Transactional
+    public void postChildComment(final ChildCommentCreateRequest request,
+                                  final LoginMember loginMember) {
+        Member member = getMember(loginMember);
+        Board board = findBoard(request.boardId());
+        Comment comment = Comment.childOf(request, board, member);
+        board.addComment(comment);
+
+        commentRepository.save(comment);
+    }
+
+    @Transactional(readOnly = true)
+    public List<BoardResponse> getCommentedBoardPage(final LoginMember loginMember, final Pageable pageable) {
+        return commentCustomRepository.getCommentedBoardPage(loginMember.memberId(), pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentResponse> getCommentsByBoardId(final Long boardId) {
+        List<Comment> comments = commentCustomRepository.getCommentsByBoardId(boardId);
+        ArrayList<CommentResponse> result = new ArrayList<>();
+
+        for(Comment comment : comments) {
+            if (!comment.isParent()) continue;
+            CommentResponse parentComment = comment.getCommentResponse();
+
+            List<CommentResponse> childrenComment = comments.stream()
+                    .filter(c -> (c.isChildFrom(comment.getId())))
+                    .map(Comment::getCommentResponse)
+                    .toList();
+
+            if(childrenComment != null && !childrenComment.isEmpty()) {
+                parentComment.setChildren(childrenComment);
+            }
+            result.add(parentComment);
+        }
+        return result;
+    }
+
+    @Transactional
+    public void deleteComment(final LoginMember loginMember, final Long commentId) {
+        Comment comment = getComment(commentId);
+        if(!comment.isWriter(loginMember.memberId())) throw new RestApiException(BoardError.INVALID_COMMENT_WRITER);
+        comment.deleteComment();
+    }
+
+    private Comment getComment(final Long commentId) {
+        return commentRepository.findById(commentId).orElseThrow(() -> new RestApiException(BoardError.INVALID_COMMENT_ID));
+    }
+}

--- a/src/main/java/com/aliens/backend/board/service/GreatService.java
+++ b/src/main/java/com/aliens/backend/board/service/GreatService.java
@@ -1,0 +1,72 @@
+package com.aliens.backend.board.service;
+
+import com.aliens.backend.auth.controller.dto.LoginMember;
+import com.aliens.backend.auth.domain.Member;
+import com.aliens.backend.auth.domain.repository.MemberRepository;
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.domain.Board;
+import com.aliens.backend.board.domain.Great;
+import com.aliens.backend.board.domain.repository.BoardRepository;
+import com.aliens.backend.board.domain.repository.GreatRepository;
+import com.aliens.backend.board.domain.repository.custom.GreatCustomRepository;
+import com.aliens.backend.global.exception.RestApiException;
+import com.aliens.backend.global.response.error.BoardError;
+import com.aliens.backend.global.response.error.MemberError;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class GreatService {
+    private final GreatRepository greatRepository;
+    private final MemberRepository memberRepository;
+    private final BoardRepository boardRepository;
+    private final GreatCustomRepository greatCustomRepository;
+
+    public GreatService(final GreatRepository greatRepository,
+                        final MemberRepository memberRepository,
+                        final BoardRepository boardRepository,
+                        final GreatCustomRepository greatCustomRepository) {
+        this.greatRepository = greatRepository;
+        this.memberRepository = memberRepository;
+        this.boardRepository = boardRepository;
+        this.greatCustomRepository = greatCustomRepository;
+    }
+
+    @Transactional
+    public void greatAtBoard(final Long id, final LoginMember loginMember) {
+        Board board = findBoardById(id);
+        Member member = getMember(loginMember);
+
+        if (isAlreadyExit(board, member)) return;
+
+        Great great = Great.of(board, member);
+        board.addGreat(great);
+        greatRepository.save(great);
+    }
+
+    private boolean isAlreadyExit(final Board board, final Member member) {
+        if(greatRepository.existsByMemberAndBoard(member, board)) {
+            greatRepository.deleteGreatByMemberAndBoard(member, board);
+            board.minusGreatCount();
+            return true;
+        }
+        return false;
+    }
+
+    private Member getMember(final LoginMember loginMember) {
+        return memberRepository.findById(loginMember.memberId()).orElseThrow(() -> new RestApiException(MemberError.NULL_MEMBER));
+    }
+
+    private Board findBoardById(final Long boardId) {
+        return boardRepository.findById(boardId).orElseThrow(() -> new RestApiException(BoardError.INVALID_BOARD_ID));
+    }
+
+    @Transactional(readOnly = true)
+    public List<BoardResponse> getGreatBoardPage(final LoginMember loginMember, Pageable pageable) {
+        return greatCustomRepository.getGreatBoardPage(loginMember.memberId(), pageable);
+    }
+}

--- a/src/main/java/com/aliens/backend/global/config/QuerydslConfig.java
+++ b/src/main/java/com/aliens/backend/global/config/QuerydslConfig.java
@@ -1,0 +1,21 @@
+package com.aliens.backend.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    private final EntityManager em;
+
+    public QuerydslConfig(final EntityManager em) {
+        this.em = em;
+    }
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em){
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/aliens/backend/global/response/error/BoardError.java
+++ b/src/main/java/com/aliens/backend/global/response/error/BoardError.java
@@ -1,0 +1,36 @@
+package com.aliens.backend.global.response.error;
+
+import org.springframework.http.HttpStatus;
+
+public enum BoardError implements ErrorCode {
+
+    INVALID_BOARD_ID(HttpStatus.BAD_REQUEST, "B1", "올바르지 않은 게시판 아이디입니다."),
+    NOT_WRITER(HttpStatus.BAD_REQUEST,"B2" ,"게시글 생성자가 아닙니다." ),
+    INVALID_COMMENT_ID(HttpStatus.BAD_REQUEST,"B3" ,"올바르지 않은 댓글 아이디입니다." ),
+    INVALID_COMMENT_WRITER(HttpStatus.BAD_REQUEST,"B4" ,"댓글 저자가 아닙니다." );
+
+    private final HttpStatus httpStatusCode;
+    private final String developCode;
+    private final String message;
+
+    BoardError(final HttpStatus httpStatusCode, final String code, final String message) {
+        this.httpStatusCode = httpStatusCode;
+        this.developCode = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatusCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getDevelopCode() {
+        return developCode;
+    }
+}

--- a/src/main/java/com/aliens/backend/global/response/success/BoardSuccess.java
+++ b/src/main/java/com/aliens/backend/global/response/success/BoardSuccess.java
@@ -1,0 +1,40 @@
+package com.aliens.backend.global.response.success;
+
+import org.springframework.http.HttpStatus;
+
+public enum BoardSuccess implements SuccessCode {
+    POST_BOARD_SUCCESS(HttpStatus.OK, "B001", "게시글 등록에 성공했습니다."),
+    GET_ALL_BOARDS_SUCCESS(HttpStatus.OK, "B002", "전체 게시글 조회에 성공했습니다."),
+    GET_ALL_BOARDS_WITH_CATEGORY_SUCCESS(HttpStatus.OK, "B003", "카테고리에 따른 게시글 조회에 성공했습니다."),
+    SEARCH_ALL_BOARDS_SUCCESS(HttpStatus.OK, "B004", "전체 게시글 검색에 성공했습니다."),
+    GET_ALL_ANNOUNCEMENT_BOARDS_SUCCESS(HttpStatus.OK, "B005", "공지사항 게시글 조회에 성공했습니다."),
+    GET_MY_BOARD_PAGE_SUCCESS(HttpStatus.OK, "B006", "본인이 작성한 게시글 조회에 성공했습니다."),
+    SEARCH_BOARD_WITH_CATEGORY_SUCCESS(HttpStatus.OK, "B007", "특정 카테고리의 게시글 검색에 성공했습니다."),
+    DELETE_BOARD_SUCCESS(HttpStatus.OK, "B008", "게시글 삭제에 성공했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    BoardSuccess(final HttpStatus httpStatus, final String code, final String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/aliens/backend/global/response/success/CommentSuccess.java
+++ b/src/main/java/com/aliens/backend/global/response/success/CommentSuccess.java
@@ -1,0 +1,37 @@
+package com.aliens.backend.global.response.success;
+
+import org.springframework.http.HttpStatus;
+
+public enum CommentSuccess implements SuccessCode {
+    PARENT_COMMENT_CREATE_SUCCESS(HttpStatus.OK, "C001", "부모 댓글 작성에 성공했습니다."),
+    CHILD_COMMENT_CREATE_SUCCESS(HttpStatus.OK, "C002", "자식 댓글 작성에 성공했습니다."),
+    GET_MY_COMMENTED_BOARD_PAGE_SUCCESS(HttpStatus.OK, "C003", "본인이 댓글단 게시글 조회에 성공했습니다."),
+    GET_COMMENTS_BY_BOARD_ID_SUCCESS(HttpStatus.OK, "C004", "해당 게시글의 모든 댓글 조회에 성공했습니다"),
+    DELETE_COMMENT_SUCCESS(HttpStatus.OK, "C005", "댓글 삭제에 성공했습니다"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    CommentSuccess(final HttpStatus httpStatus, final String code, final String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/aliens/backend/global/response/success/GreatSuccess.java
+++ b/src/main/java/com/aliens/backend/global/response/success/GreatSuccess.java
@@ -1,0 +1,35 @@
+package com.aliens.backend.global.response.success;
+
+import org.springframework.http.HttpStatus;
+
+public enum GreatSuccess implements SuccessCode {
+    GREAT_AT_BOARD_SUCCESS(HttpStatus.OK, "G001", "게시글 좋아요 등록에 성공했습니다."),
+    GET_ALL_GREAT_BOARDS_SUCCESS(HttpStatus.OK, "G002", "좋아요한 게시글 전체 조회에 성공했습니다."),
+    DELETE_AT_BOARD_SUCCESS(HttpStatus.OK, "G003", "게시글 좋아요 취소에 성공했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    GreatSuccess(final HttpStatus httpStatus, final String code, final String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/aliens/backend/global/response/success/MarketBoardSuccess.java
+++ b/src/main/java/com/aliens/backend/global/response/success/MarketBoardSuccess.java
@@ -1,0 +1,37 @@
+package com.aliens.backend.global.response.success;
+
+import org.springframework.http.HttpStatus;
+
+public enum MarketBoardSuccess implements SuccessCode {
+    CREATE_MARKET_BOARD_SUCCESS(HttpStatus.OK, "MB001", "장터 게시글 등록에 성공했습니다."),
+    GET_MARKET_BOARD_PAGE_SUCCESS(HttpStatus.OK, "MB002", "장터 게시글 조회에 성공했습니다."),
+    GET_MARKET_BOARD_DETAILS_SUCCESS(HttpStatus.OK, "MB003", "장터 게시글 상세 조회에 성공했습니다."),
+    SEARCH_MARKET_BOARD_SUCCESS(HttpStatus.OK, "MB004", "장터 게시글 검색에 성공했습니다."),
+    CHANGE_MARKET_BOARD_SUCCESS(HttpStatus.OK, "MB004", "장터 게시글 수정에 성공했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    MarketBoardSuccess(final HttpStatus httpStatus, final String code, final String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/aliens/backend/global/response/success/ReportSuccess.java
+++ b/src/main/java/com/aliens/backend/global/response/success/ReportSuccess.java
@@ -1,0 +1,33 @@
+package com.aliens.backend.global.response.success;
+
+import org.springframework.http.HttpStatus;
+
+public enum ReportSuccess implements SuccessCode {
+    REPORT_BOARD_SUCCESS(HttpStatus.OK, "R001", "게시글 신고가 완료되었습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    ReportSuccess(final HttpStatus httpStatus, final String code, final String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/aliens/backend/member/controller/MemberController.java
+++ b/src/main/java/com/aliens/backend/member/controller/MemberController.java
@@ -22,7 +22,7 @@ public class MemberController {
     }
 
     @PostMapping()
-    public SuccessResponse<String> signUp(@RequestPart SignUpRequest signUpRequest,
+    public SuccessResponse<String> signUp(@RequestBody SignUpRequest signUpRequest,
                                     @RequestPart MultipartFile profileImage) {
 
         return SuccessResponse.of(

--- a/src/main/java/com/aliens/backend/member/controller/dto/EncodedMember.java
+++ b/src/main/java/com/aliens/backend/member/controller/dto/EncodedMember.java
@@ -3,6 +3,5 @@ package com.aliens.backend.member.controller.dto;
 public record EncodedMember(String gender,
                             String mbti,
                             String birthday,
-                            String nationality,
                             String aboutMe){
 }

--- a/src/main/java/com/aliens/backend/member/controller/dto/EncodedMemberPage.java
+++ b/src/main/java/com/aliens/backend/member/controller/dto/EncodedMemberPage.java
@@ -2,7 +2,6 @@ package com.aliens.backend.member.controller.dto;
 
 public record EncodedMemberPage(String mbti,
                                 String gender,
-                                String nationality,
                                 String birthday,
                                 String aboutMe) {
 }

--- a/src/main/java/com/aliens/backend/member/controller/dto/EncodedSignUp.java
+++ b/src/main/java/com/aliens/backend/member/controller/dto/EncodedSignUp.java
@@ -2,5 +2,6 @@ package com.aliens.backend.member.controller.dto;
 
 public record EncodedSignUp(String name,
                             String email,
-                            String password) {
+                            String password,
+                            String nationality) {
 }

--- a/src/main/java/com/aliens/backend/member/controller/dto/MemberPage.java
+++ b/src/main/java/com/aliens/backend/member/controller/dto/MemberPage.java
@@ -1,5 +1,6 @@
 package com.aliens.backend.member.controller.dto;
 
 public record MemberPage(String name,
+                         String nationality,
                          String profileImageURL) {
 }

--- a/src/main/java/com/aliens/backend/member/domain/MemberImage.java
+++ b/src/main/java/com/aliens/backend/member/domain/MemberImage.java
@@ -1,10 +1,11 @@
 package com.aliens.backend.member.domain;
 
+import com.aliens.backend.auth.domain.Member;
 import com.aliens.backend.uploader.dto.S3File;
 import jakarta.persistence.*;
 
 @Entity
-public class Image {
+public class MemberImage {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column
@@ -16,14 +17,18 @@ public class Image {
     @Column
     String url;
 
-    protected Image() {
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    protected MemberImage() {
     }
 
-    public static Image from(final S3File imageFile) {
-        Image image = new Image();
-        image.name = imageFile.fileName();
-        image.url = imageFile.fileURL();
-        return image;
+    public static MemberImage from(final S3File imageFile) {
+        MemberImage memberImage = new MemberImage();
+        memberImage.name = imageFile.fileName();
+        memberImage.url = imageFile.fileURL();
+        return memberImage;
     }
 
     public void change(final S3File newFile) {

--- a/src/main/java/com/aliens/backend/member/domain/MemberInfo.java
+++ b/src/main/java/com/aliens/backend/member/domain/MemberInfo.java
@@ -23,9 +23,6 @@ public class MemberInfo {
     private String gender;
 
     @Column
-    private String nationality;
-
-    @Column
     private String birthday;
 
     @Column(name = "about_me")
@@ -39,7 +36,6 @@ public class MemberInfo {
         memberInfo.member =member;
         memberInfo.gender = request.gender();
         memberInfo.mbti = request.mbti();
-        memberInfo.nationality = request.nationality();
         memberInfo.birthday = request.birthday();
         memberInfo.aboutMe = request.aboutMe();
         return memberInfo;
@@ -54,6 +50,6 @@ public class MemberInfo {
     }
 
     public EncodedMemberPage getMemberPage() {
-        return new EncodedMemberPage(mbti,gender,nationality,birthday,aboutMe);
+        return new EncodedMemberPage(mbti,gender,birthday,aboutMe);
     }
 }

--- a/src/main/java/com/aliens/backend/member/domain/repository/ImageRepository.java
+++ b/src/main/java/com/aliens/backend/member/domain/repository/ImageRepository.java
@@ -1,9 +1,0 @@
-package com.aliens.backend.member.domain.repository;
-
-import com.aliens.backend.member.domain.Image;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface ImageRepository extends JpaRepository<Image, Long> {
-}

--- a/src/test/java/com/aliens/backend/board/service/BoardServiceReadTest.java
+++ b/src/test/java/com/aliens/backend/board/service/BoardServiceReadTest.java
@@ -1,0 +1,264 @@
+package com.aliens.backend.board.service;
+
+import com.aliens.backend.auth.controller.dto.LoginMember;
+import com.aliens.backend.auth.domain.Member;
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.controller.dto.response.MarketBoardResponse;
+import com.aliens.backend.board.domain.enums.BoardCategory;
+import com.aliens.backend.global.BaseIntegrationTest;
+import com.aliens.backend.global.DummyGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class BoardServiceReadTest extends BaseIntegrationTest {
+
+    @Autowired
+    BoardReadService boardReadService;
+
+    @Autowired
+    DummyGenerator dummyGenerator;
+
+    LoginMember givenLoginMember;
+    Member givenMember;
+    PageRequest givenPageable = PageRequest.of(0, 10);
+
+    @BeforeEach
+    void setUp() {
+        givenMember = dummyGenerator.generateSingleMember();
+        givenLoginMember = givenMember.getLoginMember();
+    }
+
+    @Test
+    @DisplayName("전체 게시판 조회")
+    void getAllBoardPageTest() {
+        //Given
+        for (int i = 0; i < 3; i++) {
+            dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.FREE);
+        }
+
+        //When
+        List<BoardResponse> response = boardReadService.getBoardPage(givenPageable);
+
+        //Then
+        assertAll(
+                () -> assertThat(response).hasSize(3),
+                () -> assertThat(response).extracting("id").containsAnyElementsOf(List.of(1L, 2L, 3L)),
+                () -> assertThat(response).extracting("title").contains(DummyGenerator.GIVEN_BOARD_TITLE),
+                () -> assertThat(response).extracting("content").contains(DummyGenerator.GIVEN_BOARD_CONTENT),
+                () -> assertThat(response).extracting("greatCount").containsOnly(1L),
+                () -> assertThat(response).extracting("commentCount").containsOnly(1L)
+        );
+    }
+
+    @Test
+    @DisplayName("카테고리 게시판 조회")
+    void getBoardPageWithCategoryTest() {
+        //Given
+        String GIVEN_CATEGORY = "fashion";
+        dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.FASHION);
+        dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.FASHION);
+        dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.ALL);
+
+        //When
+        List<BoardResponse> response = boardReadService.getBoardPageWithCategory(GIVEN_CATEGORY, givenPageable);
+
+        //Then
+        assertAll(
+                () -> assertThat(response).hasSize(2),
+                () -> assertThat(response).extracting("id").containsAnyElementsOf(List.of(1L, 2L, 3L)),
+                () -> assertThat(response).extracting("title").contains(DummyGenerator.GIVEN_BOARD_TITLE),
+                () -> assertThat(response).extracting("content").contains(DummyGenerator.GIVEN_BOARD_CONTENT),
+                () -> assertThat(response).extracting("greatCount").containsOnly(1L),
+                () -> assertThat(response).extracting("commentCount").containsOnly(1L)
+        );
+    }
+
+    @Test
+    @DisplayName("전체 게시판 검색")
+    void searchBoardPageWithKeywordTest() {
+        //Given
+        for(int i = 0; i < 5; i++) {
+            dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.FASHION);
+        }
+        String GIVEN_CONTENT = "임시";
+        dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.FASHION, GIVEN_CONTENT + "hi");
+        dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.ALL,GIVEN_CONTENT + "nice to meet you");
+
+        //When
+        List<BoardResponse> response = boardReadService.searchBoardPageWithKeyword(GIVEN_CONTENT, givenPageable);
+
+        //Then
+        assertAll(
+                () -> assertThat(response).hasSize(2),
+                () -> assertThat(response).extracting("id").containsAnyElementsOf(List.of(6L, 7L)),
+                () -> assertThat(response).extracting("title").contains(DummyGenerator.GIVEN_BOARD_TITLE),
+                () -> assertThat(response).extracting("content").allMatch(content -> ((String) content).startsWith(GIVEN_CONTENT)),
+                () -> assertThat(response).extracting("greatCount").containsOnly(1L),
+                () -> assertThat(response).extracting("commentCount").containsOnly(1L)
+        );
+    }
+
+    @Test
+    @DisplayName("공지사항 게시판 조회")
+    void getAnnouncePageTest() {
+        //Given
+        for(int i = 0; i < 5; i++) {
+            dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.FASHION);
+        }
+        dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.ANNOUNCEMENT);
+        dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.ANNOUNCEMENT);
+
+        //When
+        List<BoardResponse> response = boardReadService.getAnnouncePage(givenPageable);
+
+        //Then
+        assertAll(
+                () -> assertThat(response).hasSize(2),
+                () -> assertThat(response).extracting("id").containsAnyElementsOf(List.of(6L, 7L)),
+                () -> assertThat(response).extracting("title").contains(DummyGenerator.GIVEN_BOARD_TITLE),
+                () -> assertThat(response).extracting("content").contains(DummyGenerator.GIVEN_BOARD_CONTENT),
+                () -> assertThat(response).extracting("greatCount").containsOnly(1L),
+                () -> assertThat(response).extracting("commentCount").containsOnly(1L)
+        );
+    }
+
+    @Test
+    @DisplayName("장터 게시판 조회")
+    void getMarketBoardPageTest() {
+        //Given
+        for (int i = 0; i < 5; i++) {
+            dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.FASHION);
+        }
+        dummyGenerator.generateSingleMarketBoard(givenMember);
+        dummyGenerator.generateSingleMarketBoard(givenMember);
+
+        //When
+        List<MarketBoardResponse> response = boardReadService.getMarketBoardPage(givenPageable);
+
+        //Then
+        assertAll(
+                () -> assertThat(response).hasSize(2),
+                () -> assertThat(response).extracting("id").containsAnyElementsOf(List.of(6L, 7L)),
+                () -> assertThat(response).extracting("title").contains(DummyGenerator.GIVEN_BOARD_TITLE),
+                () -> assertThat(response).extracting("content").contains(DummyGenerator.GIVEN_BOARD_CONTENT),
+                () -> assertThat(response).extracting("greatCount").containsOnly(1L),
+                () -> assertThat(response).extracting("commentCount").containsOnly(1L),
+                () -> assertThat(response).extracting("price").allMatch(p -> p.equals(DummyGenerator.GIVEN_PRICE)),
+                () -> assertThat(response).extracting("saleStatus").allMatch(s -> s.equals(DummyGenerator.GIVEN_SALE_STATUS)),
+                () -> assertThat(response).extracting("productStatus").allMatch(p -> p.equals(DummyGenerator.GIVEN_PRODUCT_STATUS))
+        );
+    }
+
+    @Test
+    @DisplayName("장터 게시판 상세조회")
+    void getMarketBoardDetailsTest() {
+        //Given
+        dummyGenerator.generateSingleMarketBoard(givenMember);
+
+        //When
+        MarketBoardResponse response = boardReadService.getMarketBoardDetails(1L);
+
+        //Then
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.title()).contains(DummyGenerator.GIVEN_BOARD_TITLE);
+        assertThat(response.content()).contains(DummyGenerator.GIVEN_BOARD_CONTENT);
+        assertThat(response.greatCount()).isEqualTo(1L);
+        assertThat(response.greatCount()).isEqualTo(1L);
+        assertThat(response.price()).isEqualTo(DummyGenerator.GIVEN_PRICE);
+        assertThat(response.saleStatus()).isEqualTo(DummyGenerator.GIVEN_SALE_STATUS);
+        assertThat(response.productStatus()).isEqualTo(DummyGenerator.GIVEN_PRODUCT_STATUS);
+    }
+
+    @Test
+    @DisplayName("장터 게시판 검색")
+    void searchMarketBoardPageTest() {
+        //Given
+        for (int i = 0; i < 10; i++) {
+            dummyGenerator.generateSingleMarketBoard(givenMember);
+        }
+        String givenContent = "임시";
+        dummyGenerator.generateSingleMarketBoard(givenMember, givenContent + "hi");
+        dummyGenerator.generateSingleMarketBoard(givenMember, givenContent + "nice to meet you");
+
+        //When
+        List<MarketBoardResponse> response = boardReadService.searchMarketBoardPage(givenContent, givenPageable);
+
+        //Then
+        assertAll(
+                () -> assertThat(response).hasSize(2),
+                () -> assertThat(response).extracting("id").containsAnyOf(11L, 12L),
+                () -> assertThat(response).extracting("title").contains(DummyGenerator.GIVEN_BOARD_TITLE),
+                () -> assertThat(response).extracting("content").allMatch(c -> c.toString().contains(givenContent)),
+                () -> assertThat(response).extracting("greatCount").containsOnly(1L),
+                () -> assertThat(response).extracting("commentCount").containsOnly(1L),
+                () -> assertThat(response).extracting("price").allMatch(p -> p.equals(DummyGenerator.GIVEN_PRICE)),
+                () -> assertThat(response).extracting("saleStatus").allMatch(s -> s.equals(DummyGenerator.GIVEN_SALE_STATUS)),
+                () -> assertThat(response).extracting("productStatus").allMatch(p -> p.equals(DummyGenerator.GIVEN_PRODUCT_STATUS))
+        );
+    }
+
+    @Test
+    @DisplayName("내가 작성한 게시글 조회")
+    void getMyBoardPageTest() {
+        //Given
+        for (int i = 0; i < 5; i++) {
+            dummyGenerator.generateSingleMarketBoard(givenMember);
+            dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.FASHION);
+        }
+
+
+        Member newMember = dummyGenerator.generateSingleMember();
+        LoginMember loginMember = newMember.getLoginMember();
+
+        String givenContent = "개인적으로쓴 글";
+        dummyGenerator.generateSingleMarketBoard(newMember,givenContent);
+        dummyGenerator.generateSingleMarketBoard(newMember,givenContent);
+
+        //When
+        List<BoardResponse> response = boardReadService.getMyBoardPage(loginMember, givenPageable);
+
+        //Then
+        assertAll(
+                () -> assertThat(response).hasSize(2),
+                () -> assertThat(response).extracting("id").containsAnyOf(11L, 12L),
+                () -> assertThat(response).extracting("title").contains(DummyGenerator.GIVEN_BOARD_TITLE),
+                () -> assertThat(response).extracting("content").allMatch(c -> c.toString().contains(givenContent)),
+                () -> assertThat(response).extracting("greatCount").containsOnly(1L),
+                () -> assertThat(response).extracting("commentCount").containsOnly(1L)
+        );
+    }
+
+    @Test
+    @DisplayName("카테고리와 키워드를 갖고 게시글 검색")
+    void searchBoardPageWithKeywordAndCategoryTest() {
+        //Given
+        for (int i = 0; i < 5; i++) {
+            dummyGenerator.generateSingleMarketBoard(givenMember);
+            dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.FASHION);
+        }
+
+        String givenContent = "개인적으로쓴 글";
+        dummyGenerator.generateSingleMarketBoard(givenMember,givenContent);
+        dummyGenerator.generateSingleMarketBoard(givenMember,givenContent);
+
+        //When
+        List<BoardResponse> response = boardReadService.searchBoardPageWithKeywordAndCategory("개인", "market", givenPageable);
+
+        //Then
+        assertAll(
+                () -> assertThat(response).hasSize(2),
+                () -> assertThat(response).extracting("id").containsAnyOf(11L, 12L),
+                () -> assertThat(response).extracting("title").contains(DummyGenerator.GIVEN_BOARD_TITLE),
+                () -> assertThat(response).extracting("content").allMatch(c -> c.toString().contains(givenContent)),
+                () -> assertThat(response).extracting("greatCount").containsOnly(1L),
+                () -> assertThat(response).extracting("commentCount").containsOnly(1L)
+        );
+    }
+}

--- a/src/test/java/com/aliens/backend/board/service/BoardServiceTest.java
+++ b/src/test/java/com/aliens/backend/board/service/BoardServiceTest.java
@@ -1,0 +1,164 @@
+package com.aliens.backend.board.service;
+
+import com.aliens.backend.auth.controller.dto.LoginMember;
+import com.aliens.backend.auth.domain.Member;
+import com.aliens.backend.board.controller.dto.request.MarketChangeRequest;
+import com.aliens.backend.board.controller.dto.request.BoardCreateRequest;
+import com.aliens.backend.board.controller.dto.request.MarketBoardCreateRequest;
+import com.aliens.backend.board.domain.Board;
+import com.aliens.backend.board.domain.enums.BoardCategory;
+import com.aliens.backend.board.domain.enums.ProductStatus;
+import com.aliens.backend.board.domain.enums.SaleStatus;
+import com.aliens.backend.board.domain.repository.BoardRepository;
+import com.aliens.backend.global.BaseIntegrationTest;
+import com.aliens.backend.global.DummyGenerator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+class BoardServiceTest extends BaseIntegrationTest {
+    @Autowired BoardService boardService;
+    @Autowired BoardRepository boardRepository;
+    @Autowired DummyGenerator dummyGenerator;
+
+    MultipartFile file;
+    LoginMember givenLoginMember;
+    String givenTitle = "제목";
+    String givenContent = "내용";
+    Member givenMember;
+
+
+    @BeforeEach
+    void setUp() {
+        givenMember = dummyGenerator.generateSingleMember();
+        givenLoginMember = givenMember.getLoginMember();
+        file = dummyGenerator.generateMultipartFile();
+    }
+
+    @Test
+    @DisplayName("일반 게시물 등록")
+    void postNormalBoardTest() {
+        //Given
+        final BoardCategory givenCategory = BoardCategory.ALL;
+        final List<MultipartFile> givenFiles = List.of(file);
+        BoardCreateRequest request = new BoardCreateRequest(givenTitle, givenContent, givenCategory);
+
+        //When
+        boardService.postNormalBoard(request, givenFiles, givenLoginMember);
+
+        //Then
+        final Board response = boardRepository.findAllWithBoardImage().get(0);
+        Assertions.assertEquals(1, response.getImages().size());
+        Assertions.assertTrue(response.isSameWithRequest(request));
+    }
+
+    @Test
+    @DisplayName("일반 게시물 등록 - 이미지 없음")
+    void postNormalBoardWithOutImagesTest() {
+        //Given
+        final BoardCategory givenCategory = BoardCategory.ALL;
+        final BoardCreateRequest request = new BoardCreateRequest(givenTitle, givenContent, givenCategory);
+
+        //When
+        boardService.postNormalBoard(request, null, givenLoginMember);
+
+        //Then
+        final Board response = boardRepository.findAllWithBoardImage().get(0);
+        Assertions.assertTrue(response.getImages().isEmpty());
+        Assertions.assertTrue(response.isSameWithRequest(request));
+    }
+
+    @Test
+    @DisplayName("장터 게시물 등록")
+    void postMarketBoardTest() {
+        //Given
+        final List<MultipartFile> givenFiles = List.of(file);
+        final String givenPrice = "10000";
+        MarketBoardCreateRequest request = new MarketBoardCreateRequest(
+                givenTitle,
+                givenContent,
+                SaleStatus.SELL,
+                givenPrice,
+                ProductStatus.ALMOST_NEW);
+
+        //When
+        boardService.postMarketBoard(request, givenFiles, givenLoginMember);
+
+        //Then
+        final Board response = boardRepository.findAlLWithMarketInfo().get(0);
+        final BoardCreateRequest boardCreateRequest = BoardCreateRequest.from(request);
+
+        Assertions.assertEquals(1, response.getImages().size());
+        Assertions.assertTrue(response.isSameWithRequest(boardCreateRequest));
+        Assertions.assertEquals(response.getPrice(), givenPrice);
+    }
+
+    @Test
+    @DisplayName("장터 게시물 등록 - 이미지 없음")
+    void postMarketBoardWithOutImagesTest() {
+        //Given
+        final String givenPrice = "10000";
+        final MarketBoardCreateRequest request = new MarketBoardCreateRequest(givenTitle,
+                givenContent,
+                SaleStatus.SELL,
+                givenPrice,
+                ProductStatus.ALMOST_NEW);
+
+        //When
+        boardService.postMarketBoard(request, null, givenLoginMember);
+
+        //Then
+        final Board response = boardRepository.findAlLWithMarketInfo().get(0);
+        final BoardCreateRequest boardCreateRequest = BoardCreateRequest.from(request);
+
+        Assertions.assertTrue(response.getImages().isEmpty());
+        Assertions.assertTrue(response.isSameWithRequest(boardCreateRequest));
+        Assertions.assertEquals(response.getPrice(), givenPrice);
+    }
+
+    @Test
+    @DisplayName("장터 게시물 수정")
+    void changeMarketBoardTest() {
+        //Given
+        dummyGenerator.generateSingleMarketBoard(givenMember);
+
+        final String changeTitle = "수정 제목";
+        final String changeContent = "수정 내용";
+        final SaleStatus changeSaleStatus = SaleStatus.END;
+        final String changePrice = "100";
+        final ProductStatus changeProductStatus = ProductStatus.SLIGHT_DEFECT;
+        final MarketChangeRequest request = new MarketChangeRequest(
+                changeTitle,
+                changeContent,
+                changeSaleStatus,
+                changePrice,
+                changeProductStatus);
+
+        //When
+        boardService.changeMarketBoard(1L, request, givenLoginMember);
+
+        //Then
+        final Board response = boardRepository.findAlLWithMarketInfo().get(0);
+
+        Assertions.assertEquals(2, response.getImages().size());
+        Assertions.assertTrue(response.isSameWithRequest(request));
+    }
+
+    @Test
+    @DisplayName("게시물 삭제")
+    void deleteBoardTest() {
+        //Given
+        dummyGenerator.generateSingleMarketBoard(givenMember);
+
+        //When
+        boardService.deleteBoard(givenLoginMember, 1L);
+
+        //Then
+        Assertions.assertNull(boardRepository.findById(1L).orElse(null));
+    }
+}

--- a/src/test/java/com/aliens/backend/board/service/CommentServiceTest.java
+++ b/src/test/java/com/aliens/backend/board/service/CommentServiceTest.java
@@ -1,0 +1,179 @@
+package com.aliens.backend.board.service;
+
+import com.aliens.backend.auth.controller.dto.LoginMember;
+import com.aliens.backend.auth.domain.Member;
+import com.aliens.backend.board.controller.dto.response.CommentResponse;
+import com.aliens.backend.board.controller.dto.request.ParentCommentCreateRequest;
+import com.aliens.backend.board.controller.dto.request.ChildCommentCreateRequest;
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.domain.Board;
+import com.aliens.backend.board.domain.Comment;
+import com.aliens.backend.board.domain.enums.BoardCategory;
+import com.aliens.backend.board.domain.enums.CommentStatus;
+import com.aliens.backend.board.domain.repository.BoardRepository;
+import com.aliens.backend.board.domain.repository.CommentRepository;
+import com.aliens.backend.global.BaseIntegrationTest;
+import com.aliens.backend.global.DummyGenerator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+
+class CommentServiceTest extends BaseIntegrationTest {
+    @Autowired
+    CommentService commentService;
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    @Autowired
+    BoardRepository boardRepository;
+
+    @Autowired
+    DummyGenerator dummyGenerator;
+
+    Member givenMember;
+    LoginMember givenLoginMember;
+
+
+    @BeforeEach
+    void setUp() {
+        givenMember = dummyGenerator.generateSingleMember();
+        givenLoginMember = givenMember.getLoginMember();
+    }
+
+    @Test
+    @DisplayName("부모 댓글 등록")
+    void postParentCommentTest() {
+        //Given
+        Board givenBoard = dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.FREE);
+        String givenContent = "댓글 내용";
+        ParentCommentCreateRequest request = new ParentCommentCreateRequest(givenBoard.getId(), givenContent);
+
+        //When
+        commentService.postParentComment(request, givenLoginMember);
+
+        //Then
+        Comment response = commentRepository.findAll().get(1);
+        Assertions.assertEquals(givenContent, response.getContent());
+    }
+
+    @Test
+    @DisplayName("자식 댓글 등록")
+    void postChildCommentTest() {
+        //Given
+        Board givenBoard = dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.FREE);
+
+        String givenParentContent = "부모 댓글 내용";
+        Comment parentComment = Comment.parentOf(givenParentContent, givenBoard, givenMember);
+        commentRepository.save(parentComment);
+
+        String givenChildContent = "자식 댓글 내용";
+        ChildCommentCreateRequest request = new ChildCommentCreateRequest(
+                givenBoard.getId(),
+                givenChildContent,
+                parentComment.getId());
+
+        //When
+        commentService.postChildComment(request, givenLoginMember);
+
+        //Then
+        Comment response = commentRepository.findAll().get(2);
+        Assertions.assertEquals(givenChildContent, response.getContent());
+    }
+
+    @Test
+    @DisplayName("본인이 댓글 단 게시글 조회")
+    void getCommentedBoardPageTest() {
+        //Given
+        Pageable givenPageable = PageRequest.of(0, 10);
+        for (int i = 0; i < 3; i++) {
+            dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.FREE);
+        }
+
+        //When
+        List<BoardResponse> response = commentService.getCommentedBoardPage(givenLoginMember, givenPageable);
+
+        //Then
+        assertAll(
+                () -> assertThat(response).hasSize(3),
+                () -> assertThat(response).extracting("id").containsAnyElementsOf(List.of(1L, 2L, 3L)),
+                () -> assertThat(response).extracting("title").contains(DummyGenerator.GIVEN_BOARD_TITLE),
+                () -> assertThat(response).extracting("content").contains(DummyGenerator.GIVEN_BOARD_CONTENT),
+                () -> assertThat(response).extracting("greatCount").containsOnly(1L),
+                () -> assertThat(response).extracting("commentCount").containsOnly(1L)
+        );
+    }
+
+    @Test
+    @DisplayName("주어진 게시글의 댓글 조회 - 자식 댓글 없음")
+    void getCommentsByBoardIdTest() {
+        //Given
+        dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.FREE);
+
+        //When
+        List<CommentResponse> response = commentService.getCommentsByBoardId(1L);
+
+        //Then
+        assertThat(response).hasSize(1);
+        assertThat(response).extracting("status").containsOnly(CommentStatus.ACTIVE);
+        assertThat(response).extracting("id").containsOnly(1L);
+        assertThat(response).extracting("content").contains(DummyGenerator.GIVEN_COMMENT_CONTENT);
+        assertThat(response).extracting("createdAt").isNotNull();
+        assertThat(response).extracting("children").containsNull();
+        assertThat(response).extracting("memberProfileDto").containsOnly(givenMember.getprofileDto());
+    }
+
+    @Test
+    @DisplayName("주어진 게시글의 댓글 조회 - 자식 댓글 포함")
+    void getCommentsWithChildrenByBoardIdTest() {
+        //Given
+        Board givenBoard = dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.FREE);
+
+        String givenChildContent = "자식 댓글 내용";
+        ChildCommentCreateRequest request = new ChildCommentCreateRequest(givenBoard.getId(),
+                givenChildContent,
+                1L);
+        Comment comment = Comment.childOf(request, givenBoard, givenMember);
+
+        givenBoard.addComment(comment);
+        boardRepository.save(givenBoard);
+        commentRepository.save(comment);
+
+        //When
+        List<CommentResponse> response = commentService.getCommentsByBoardId(1L);
+
+        //Then
+        assertThat(response).hasSize(1);
+        assertThat(response).extracting("status").containsOnly(CommentStatus.ACTIVE);
+        assertThat(response).extracting("id").containsOnly(1L);
+        assertThat(response).extracting("content").contains(DummyGenerator.GIVEN_COMMENT_CONTENT);
+        assertThat(response).extracting("createdAt").isNotNull();
+        assertThat(response).extracting("children").hasSize(1);
+        assertThat(response).extracting("memberProfileDto").containsOnly(givenMember.getprofileDto());
+    }
+
+
+    @Test
+    @DisplayName("댓글 삭제")
+    void deleteCommentTest() {
+        //Given
+        dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.FREE);
+
+        //When
+        commentService.deleteComment(givenLoginMember, 1L);
+
+        //Then
+        Comment comment = commentRepository.findById(1L).get();
+        Assertions.assertEquals(CommentStatus.DELETE, comment.getStatus());
+    }
+}

--- a/src/test/java/com/aliens/backend/board/service/GreatServiceTest.java
+++ b/src/test/java/com/aliens/backend/board/service/GreatServiceTest.java
@@ -1,0 +1,82 @@
+package com.aliens.backend.board.service;
+
+import com.aliens.backend.auth.controller.dto.LoginMember;
+import com.aliens.backend.auth.domain.Member;
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.domain.Board;
+import com.aliens.backend.board.domain.Great;
+import com.aliens.backend.board.domain.enums.BoardCategory;
+import com.aliens.backend.board.domain.repository.BoardRepository;
+import com.aliens.backend.board.domain.repository.GreatRepository;
+import com.aliens.backend.global.BaseIntegrationTest;
+import com.aliens.backend.global.DummyGenerator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+
+class GreatServiceTest extends BaseIntegrationTest {
+    @Autowired
+    GreatService greatService;
+
+    @Autowired
+    GreatRepository greatRepository;
+
+    @Autowired
+    DummyGenerator dummyGenerator;
+
+    @Autowired
+    BoardRepository boardRepository;
+
+    Member givenMember;
+    LoginMember givenLoginMember;
+
+    @BeforeEach
+    void setUp() {
+        givenMember = dummyGenerator.generateSingleMember();
+        givenLoginMember = givenMember.getLoginMember();
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 등록")
+    void greatAtBoardTest() {
+        //Given
+        Member newMember = dummyGenerator.generateSingleMember();
+        LoginMember newLoginMember = newMember.getLoginMember();
+        Board givenBoard = dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.FREE);
+
+        //When
+        greatService.greatAtBoard(givenBoard.getId(), newLoginMember);
+
+        // Then
+        Great response = greatRepository.findAll().get(0);
+        Assertions.assertNotNull(response);
+    }
+
+    @Test
+    @DisplayName("좋아요한 게시글 조회")
+    void getGreatBoardPageTest() {
+        //Given
+        PageRequest givenPageable = PageRequest.of(0, 10);
+        for(int i = 0; i < 3; i++) {
+            dummyGenerator.generateSingleNormalBoard(givenMember, BoardCategory.FREE);
+        }
+
+        //When
+        List<BoardResponse> response = greatService.getGreatBoardPage(givenLoginMember, givenPageable);
+
+        // Then
+        assertAll(
+                () -> assertThat(response).hasSize(3),
+                () -> assertThat(response).extracting("greatCount").containsOnly(1L)
+        );
+    }
+}

--- a/src/test/java/com/aliens/backend/docs/BaseRestDocsTest.java
+++ b/src/test/java/com/aliens/backend/docs/BaseRestDocsTest.java
@@ -3,6 +3,10 @@ package com.aliens.backend.docs;
 import com.aliens.backend.auth.controller.AuthController;
 import com.aliens.backend.auth.domain.Member;
 import com.aliens.backend.block.controller.BlockController;
+import com.aliens.backend.board.controller.BoardController;
+import com.aliens.backend.board.controller.CommentController;
+import com.aliens.backend.board.controller.GreatController;
+import com.aliens.backend.board.controller.MarketController;
 import com.aliens.backend.chat.controller.ChatController;
 import com.aliens.backend.chat.controller.ChatReportController;
 import com.aliens.backend.email.controller.EmailController;
@@ -36,6 +40,15 @@ public abstract class BaseRestDocsTest {
     protected EmailController emailController;
     @SpyBean
     protected BlockController blockController;
+    @SpyBean
+    protected BoardController boardController;
+    @SpyBean
+    protected CommentController commentController;
+    @SpyBean
+    protected GreatController greatController;
+    @SpyBean
+    protected MarketController marketBoardController;
+
 
     @Autowired
     protected MockMvc mockMvc;

--- a/src/test/java/com/aliens/backend/docs/BoardRestDocsTest.java
+++ b/src/test/java/com/aliens/backend/docs/BoardRestDocsTest.java
@@ -1,0 +1,367 @@
+package com.aliens.backend.docs;
+
+import com.aliens.backend.board.controller.dto.request.BoardCreateRequest;
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.controller.dto.response.MemberProfileDto;
+import com.aliens.backend.board.domain.enums.BoardCategory;
+import com.aliens.backend.global.response.SuccessResponse;
+import com.aliens.backend.global.response.success.BoardSuccess;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+class BoardRestDocsTest extends BaseRestDocsTest {
+
+    @Test
+    @DisplayName("API - 게시글 생성")
+    void createBoardTest() throws Exception {
+        // Given
+        final BoardCreateRequest request = new BoardCreateRequest(
+                "Title",
+                "Content",
+                BoardCategory.FREE);
+        final SuccessResponse<?> response = SuccessResponse.of(BoardSuccess.POST_BOARD_SUCCESS);
+        doReturn(response).when(boardController).createBoard(any(), any(), any());
+
+        final MockMultipartFile multipartFile = createMultipartFile();
+
+        // When & Then
+        mockMvc.perform(multipart("/boards/normal")
+                        .file("boardImages", multipartFile.getBytes())
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+
+                        .header("Authorization", GIVEN_ACCESS_TOKEN))
+
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("board-create",
+                        requestParts(
+                                partWithName("boardImages").description("게시물 등록 이미지 파일")
+                        ),
+                        requestFields(
+                                fieldWithPath("title").description("게시물 제목"),
+                                fieldWithPath("content").description("게시물 내용"),
+                                fieldWithPath("boardCategory").description("게시물 카테고리")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("회원가입 결과")
+                        )
+                ));
+    }
+
+    private MockMultipartFile createMultipartFile() {
+        return new MockMultipartFile("boardImages",
+                "test-image.png",
+                "image/png",
+                "test data".getBytes());
+    }
+
+    @Test
+    @DisplayName("API - 전체 게시글 조회")
+    void getAllBoardsTest() throws Exception {
+        // Given
+        final Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        final List<BoardResponse> boardResponses = List.of(
+                createBoardResponse(),
+                createBoardResponse());
+
+        final SuccessResponse<List<BoardResponse>> response = SuccessResponse.of(BoardSuccess.GET_ALL_BOARDS_SUCCESS, boardResponses);
+        doReturn(response).when(boardController).getAllBoards(pageable);
+
+        // When & Then
+        mockMvc.perform(get("/boards")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("api-board-get-all",
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0부터 시작)"),
+                                parameterWithName("size").description("페이지당 아이템 개수")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("게시글 조회 결과"),
+                                fieldWithPath("result[].id").description("게시글 ID"),
+                                fieldWithPath("result[].category").description("게시글 카테고리"),
+                                fieldWithPath("result[].title").description("게시글 제목"),
+                                fieldWithPath("result[].content").description("게시글 내용"),
+                                fieldWithPath("result[].greatCount").description("게시글 좋아요 수"),
+                                fieldWithPath("result[].commentCount").description("게시글 댓글 수"),
+                                fieldWithPath("result[].imageUrls").description("게시글 이미지 URL 리스트"),
+                                fieldWithPath("result[].createdAt").description("게시글 생성 시간"),
+                                fieldWithPath("result[].memberProfileDto.name").description("게시글 작성자 이름"),
+                                fieldWithPath("result[].memberProfileDto.profileImageUrl").description("게시글 작성자 프로필 이미지 URL"),
+                                fieldWithPath("result[].memberProfileDto.nationality").description("게시글 작성자 국적")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("API - 특정 카테고리 게시글 조회")
+    void getAllBoardsWithCategoryTest() throws Exception {
+        // Given
+        final String category = "FASHION";
+        final List<BoardResponse> boardResponses = List.of(
+                createBoardResponse(),
+                createBoardResponse());
+
+        final SuccessResponse<List<BoardResponse>> response = SuccessResponse.of(BoardSuccess.GET_ALL_BOARDS_WITH_CATEGORY_SUCCESS, boardResponses);
+        doReturn(response).when(boardController).getAllBoardsWithCategory(any(), any());
+
+        // When & Then
+        mockMvc.perform(get("/boards/category")
+                        .param("category", category)
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("api-board-get-all-with-category",
+                        queryParameters(
+                                parameterWithName("category").description("게시글 카테고리"),
+                                parameterWithName("page").description("페이지 번호 (0부터 시작)"),
+                                parameterWithName("size").description("페이지당 아이템 개수")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("게시글 조회 결과"),
+                                fieldWithPath("result[].id").description("게시글 ID"),
+                                fieldWithPath("result[].category").description("게시글 카테고리"),
+                                fieldWithPath("result[].title").description("게시글 제목"),
+                                fieldWithPath("result[].content").description("게시글 내용"),
+                                fieldWithPath("result[].greatCount").description("게시글 좋아요 수"),
+                                fieldWithPath("result[].commentCount").description("게시글 댓글 수"),
+                                fieldWithPath("result[].imageUrls").description("게시글 이미지 URL 리스트"),
+                                fieldWithPath("result[].createdAt").description("게시글 생성 시간"),
+                                fieldWithPath("result[].memberProfileDto.name").description("게시글 작성자 이름"),
+                                fieldWithPath("result[].memberProfileDto.profileImageUrl").description("게시글 작성자 프로필 이미지 URL"),
+                                fieldWithPath("result[].memberProfileDto.nationality").description("게시글 작성자 국적")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("API - 게시글 검색")
+    void searchAllBoardPageTest() throws Exception {
+        // Given
+        final String searchKeyword = "검색어";
+        final List<BoardResponse> boardResponses = List.of(
+                createBoardResponse(),
+                createBoardResponse());
+
+        final SuccessResponse<List<BoardResponse>> response = SuccessResponse.of(BoardSuccess.SEARCH_ALL_BOARDS_SUCCESS, boardResponses);
+        doReturn(response).when(boardController).searchAllBoardPage(any(), any());
+
+        // When & Then
+        mockMvc.perform(get("/boards/search")
+                        .param("search-keyword", searchKeyword)
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("api-board-search",
+                        queryParameters(
+                                parameterWithName("search-keyword").description("검색어"),
+                                parameterWithName("page").description("페이지 번호 (0부터 시작)"),
+                                parameterWithName("size").description("페이지당 아이템 개수")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("게시글 검색 결과"),
+                                fieldWithPath("result[].id").description("게시글 ID"),
+                                fieldWithPath("result[].category").description("게시글 카테고리"),
+                                fieldWithPath("result[].title").description("게시글 제목"),
+                                fieldWithPath("result[].content").description("게시글 내용"),
+                                fieldWithPath("result[].greatCount").description("게시글 좋아요 수"),
+                                fieldWithPath("result[].commentCount").description("게시글 댓글 수"),
+                                fieldWithPath("result[].imageUrls").description("게시글 이미지 URL 리스트"),
+                                fieldWithPath("result[].createdAt").description("게시글 생성 시간"),
+                                fieldWithPath("result[].memberProfileDto.name").description("게시글 작성자 이름"),
+                                fieldWithPath("result[].memberProfileDto.profileImageUrl").description("게시글 작성자 프로필 이미지 URL"),
+                                fieldWithPath("result[].memberProfileDto.nationality").description("게시글 작성자 국적")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("API - 공지사항 게시글 조회")
+    void getAllAnnouncementBoardsTest() throws Exception {
+        // Given
+        final List<BoardResponse> boardResponses = List.of(
+                createBoardResponse(),
+                createBoardResponse());
+
+        final SuccessResponse<List<BoardResponse>> response = SuccessResponse.of(BoardSuccess.GET_ALL_ANNOUNCEMENT_BOARDS_SUCCESS, boardResponses);
+        doReturn(response).when(boardController).getAllAnnouncementBoards(any());
+
+        // When & Then
+        mockMvc.perform(get("/boards/announcements")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("api-board-get-all-announcements",
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0부터 시작)"),
+                                parameterWithName("size").description("페이지당 아이템 개수")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("공지사항 게시글 조회 결과"),
+                                fieldWithPath("result[].id").description("게시글 ID"),
+                                fieldWithPath("result[].category").description("게시글 카테고리"),
+                                fieldWithPath("result[].title").description("게시글 제목"),
+                                fieldWithPath("result[].content").description("게시글 내용"),
+                                fieldWithPath("result[].greatCount").description("게시글 좋아요 수"),
+                                fieldWithPath("result[].commentCount").description("게시글 댓글 수"),
+                                fieldWithPath("result[].imageUrls").description("게시글 이미지 URL 리스트"),
+                                fieldWithPath("result[].createdAt").description("게시글 생성 시간"),
+                                fieldWithPath("result[].memberProfileDto.name").description("게시글 작성자 이름"),
+                                fieldWithPath("result[].memberProfileDto.profileImageUrl").description("게시글 작성자 프로필 이미지 URL"),
+                                fieldWithPath("result[].memberProfileDto.nationality").description("게시글 작성자 국적")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("API - 내가 작성한 게시글 조회")
+    void getPageMyBoardsTest() throws Exception {
+        // Given
+        final List<BoardResponse> boardResponses = List.of(
+                createBoardResponse(),
+                createBoardResponse());
+
+        final SuccessResponse<List<BoardResponse>> response = SuccessResponse.of(BoardSuccess.GET_MY_BOARD_PAGE_SUCCESS, boardResponses);
+        doReturn(response).when(boardController).getPageMyBoards(any(), any());
+
+        // When & Then
+        mockMvc.perform(get("/boards/writes")
+                        .header("Authorization", GIVEN_ACCESS_TOKEN)
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("api-board-get-my-boards",
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0부터 시작)"),
+                                parameterWithName("size").description("페이지당 아이템 개수")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("내가 작성한 게시글 조회 결과"),
+                                fieldWithPath("result[].id").description("게시글 ID"),
+                                fieldWithPath("result[].category").description("게시글 카테고리"),
+                                fieldWithPath("result[].title").description("게시글 제목"),
+                                fieldWithPath("result[].content").description("게시글 내용"),
+                                fieldWithPath("result[].greatCount").description("게시글 좋아요 수"),
+                                fieldWithPath("result[].commentCount").description("게시글 댓글 수"),
+                                fieldWithPath("result[].imageUrls").description("게시글 이미지 URL 리스트"),
+                                fieldWithPath("result[].createdAt").description("게시글 생성 시간"),
+                                fieldWithPath("result[].memberProfileDto.name").description("게시글 작성자 이름"),
+                                fieldWithPath("result[].memberProfileDto.profileImageUrl").description("게시글 작성자 프로필 이미지 URL"),
+                                fieldWithPath("result[].memberProfileDto.nationality").description("게시글 작성자 국적")
+                        )
+                ));
+    }
+
+    private BoardResponse createBoardResponse() {
+        return new BoardResponse(1L,
+                BoardCategory.FREE,
+                "제목 1",
+                "내용 1",
+                1L,
+                1L,
+                List.of("/test", "/test"),
+                Instant.now(),
+                new MemberProfileDto("작성자 이름", "/test","KOREA")
+        );
+    }
+
+    @Test
+    @DisplayName("API - 특정 카테고리 게시글 검색")
+    void searchBoardsWithCategoryTest() throws Exception {
+        // Given
+        final String searchKeyword = "검색어";
+        final String category = "FASHION";
+        final List<BoardResponse> boardResponses = List.of(
+                createBoardResponse(),
+                createBoardResponse());
+
+        final SuccessResponse<List<BoardResponse>> response = SuccessResponse.of(BoardSuccess.SEARCH_BOARD_WITH_CATEGORY_SUCCESS, boardResponses);
+        doReturn(response).when(boardController).searchBoardsWithCategory(any(), any(), any());
+
+        // When & Then
+        mockMvc.perform(get("/boards/category/search")
+                        .param("search-keyword", searchKeyword)
+                        .param("category", category)
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("api-board-search-with-category",
+                        queryParameters(
+                                parameterWithName("search-keyword").description("검색어"),
+                                parameterWithName("category").description("게시글 카테고리"),
+                                parameterWithName("page").description("페이지 번호 (0부터 시작)"),
+                                parameterWithName("size").description("페이지당 아이템 개수")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("게시글 검색 결과"),
+                                fieldWithPath("result[].id").description("게시글 ID"),
+                                fieldWithPath("result[].category").description("게시글 카테고리"),
+                                fieldWithPath("result[].title").description("게시글 제목"),
+                                fieldWithPath("result[].content").description("게시글 내용"),
+                                fieldWithPath("result[].greatCount").description("게시글 좋아요 수"),
+                                fieldWithPath("result[].commentCount").description("게시글 댓글 수"),
+                                fieldWithPath("result[].imageUrls").description("게시글 이미지 URL 리스트"),
+                                fieldWithPath("result[].createdAt").description("게시글 생성 시간"),
+                                fieldWithPath("result[].memberProfileDto.name").description("게시글 작성자 이름"),
+                                fieldWithPath("result[].memberProfileDto.profileImageUrl").description("게시글 작성자 프로필 이미지 URL"),
+                                fieldWithPath("result[].memberProfileDto.nationality").description("게시글 작성자 국적")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("API - 게시글 삭제")
+    void deleteBoardTest() throws Exception {
+        // Given
+        final SuccessResponse<?> response = SuccessResponse.of(BoardSuccess.DELETE_BOARD_SUCCESS);
+        doReturn(response).when(boardController).deleteBoard(any(), any());
+
+        // When & Then
+        mockMvc.perform(delete("/boards?id={id}", 1)
+                        .header("Authorization", GIVEN_ACCESS_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("api-board-delete",
+                        queryParameters(
+                                parameterWithName("id").description("게시글 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("게시글 삭제 결과")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/aliens/backend/docs/CommentRestDocsTest.java
+++ b/src/test/java/com/aliens/backend/docs/CommentRestDocsTest.java
@@ -1,0 +1,249 @@
+package com.aliens.backend.docs;
+
+import com.aliens.backend.board.controller.dto.response.CommentResponse;
+import com.aliens.backend.board.controller.dto.request.ParentCommentCreateRequest;
+import com.aliens.backend.board.controller.dto.request.ChildCommentCreateRequest;
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.controller.dto.response.MemberProfileDto;
+import com.aliens.backend.board.domain.enums.BoardCategory;
+import com.aliens.backend.board.domain.enums.CommentStatus;
+import com.aliens.backend.global.response.SuccessResponse;
+import com.aliens.backend.global.response.success.CommentSuccess;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class CommentRestDocsTest extends BaseRestDocsTest{
+
+    @Test
+    @DisplayName("API - 부모 댓글 작성")
+    void createParentCommentTest() throws Exception {
+        // Given
+        String content = "부모 댓글 내용";
+        ParentCommentCreateRequest request = new ParentCommentCreateRequest(1L, content);
+        final SuccessResponse<?> response = SuccessResponse.of(CommentSuccess.PARENT_COMMENT_CREATE_SUCCESS, "부모 댓글 작성에 성공했습니다.");
+        doReturn(response).when(commentController).createParentComment(any(), any());
+
+        // When & Then
+        mockMvc.perform(post("/comments/parent")
+                        .content(objectMapper.writeValueAsString(request))
+                        .header("Authorization", GIVEN_ACCESS_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+
+                .andDo(document("api-create-parent-comment",
+                        requestFields(
+                                fieldWithPath("content").description("댓글 내용"),
+                                fieldWithPath("boardId").description("게시글 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("응답 결과")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("API - 자식 댓글 작성")
+    void createChildCommentTest() throws Exception {
+        // Given
+        String givenContent = "댓글 내용";
+        ChildCommentCreateRequest request = new ChildCommentCreateRequest(1L,givenContent,1L);
+
+        final SuccessResponse<?> response = SuccessResponse.of(CommentSuccess.CHILD_COMMENT_CREATE_SUCCESS, "자식 댓글 작성에 성공했습니다.");
+        doReturn(response).when(commentController).createChildComment(any(), any());
+
+        // When & Then
+        mockMvc.perform(post("/comments/child")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", GIVEN_ACCESS_TOKEN)
+                )
+                .andExpect(status().isOk())
+
+                .andDo(document("api-create-child-comment",
+                        requestFields(
+                                fieldWithPath("boardId").description("게시글 ID"),
+                                fieldWithPath("content").description("댓글 내용"),
+                                fieldWithPath("parentCommentId").description("부모 댓글 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("응답 결과")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("API - 본인이 댓글 단 게시글 조회")
+    void getPageMyCommentedBoardsTest() throws Exception {
+        // Given
+        final List<BoardResponse> boardResponses = List.of(
+                createBoardResponse(),
+                createBoardResponse());
+
+        final SuccessResponse<List<BoardResponse>> response = SuccessResponse.of(CommentSuccess.GET_MY_COMMENTED_BOARD_PAGE_SUCCESS, boardResponses);
+        doReturn(response).when(commentController).getPageMyCommentedBoards(any(), any());
+
+        // When & Then
+        mockMvc.perform(get("/comments/my-boards")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .header("Authorization", GIVEN_ACCESS_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("api-get-commented-board-page",
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0부터 시작)"),
+                                parameterWithName("size").description("페이지당 아이템 개수")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("게시글 조회 결과"),
+                                fieldWithPath("result[].id").description("게시글 ID"),
+                                fieldWithPath("result[].category").description("게시글 카테고리"),
+                                fieldWithPath("result[].title").description("게시글 제목"),
+                                fieldWithPath("result[].content").description("게시글 내용"),
+                                fieldWithPath("result[].greatCount").description("게시글 좋아요 수"),
+                                fieldWithPath("result[].commentCount").description("게시글 댓글 수"),
+                                fieldWithPath("result[].imageUrls").description("게시글 이미지 URL 리스트"),
+                                fieldWithPath("result[].createdAt").description("게시글 생성 시간"),
+                                fieldWithPath("result[].memberProfileDto.name").description("게시글 작성자 이름"),
+                                fieldWithPath("result[].memberProfileDto.profileImageUrl").description("게시글 작성자 프로필 이미지 URL"),
+                                fieldWithPath("result[].memberProfileDto.nationality").description("게시글 작성자 국적")
+                        )
+                ));
+    }
+
+    private BoardResponse createBoardResponse() {
+        return new BoardResponse(1L,
+                BoardCategory.FREE,
+                "제목 1",
+                "내용 1",
+                1L,
+                1L,
+                List.of("/test", "/test"),
+                Instant.now(),
+                new MemberProfileDto("작성자 이름", "/test","KOREA")
+        );
+    }
+
+    @Test
+    @DisplayName("API - 해당 게시글의 모든 댓글 조회")
+    void getCommentsByBoardIdTest() throws Exception {
+        // Given
+        final List<CommentResponse> commentResponseList = List.of(createCommentResponseWithoutChildren(), createCommentResponseWithChildren());
+        final SuccessResponse<List<CommentResponse>> response = SuccessResponse.of(CommentSuccess.GET_COMMENTS_BY_BOARD_ID_SUCCESS, commentResponseList);
+        doReturn(response).when(commentController).getCommentsByBoardId(any());
+
+        // When & Then
+        mockMvc.perform(get("/comments/boards")
+                        .param("board-id", "1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("api-get-comments-by-board-id",
+                        queryParameters(
+                                parameterWithName("board-id").description("게시글 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("댓글 조회 결과"),
+                                fieldWithPath("result[].status").description("댓글 상태"),
+                                fieldWithPath("result[].id").description("댓글 ID"),
+                                fieldWithPath("result[].content").description("댓글 내용"),
+                                fieldWithPath("result[].createdAt").description("댓글 생성 시간"),
+                                fieldWithPath("result[].memberProfileDto.name").description("댓글 작성자 이름"),
+                                fieldWithPath("result[].memberProfileDto.profileImageUrl").description("댓글 작성자 프로필 이미지 URL"),
+                                fieldWithPath("result[].memberProfileDto.nationality").description("댓글 작성자 국적"),
+                                fieldWithPath("result[].children").description("자식 댓글 리스트").optional(), // 자식 댓글 리스트는 선택적(optional)으로 표시
+                                fieldWithPath("result[].children[].status").description("자식 댓글 상태"),
+                                fieldWithPath("result[].children[].id").description("자식 댓글 ID"),
+                                fieldWithPath("result[].children[].content").description("자식 댓글 내용"),
+                                fieldWithPath("result[].children[].createdAt").description("자식 댓글 생성 시간"),
+                                fieldWithPath("result[].children[].memberProfileDto.name").description("자식 댓글 작성자 이름"),
+                                fieldWithPath("result[].children[].memberProfileDto.profileImageUrl").description("자식 댓글 작성자 프로필 이미지 URL"),
+                                fieldWithPath("result[].children[].memberProfileDto.nationality").description("자식 댓글 작성자 국적"),
+                                fieldWithPath("result[].children[].children").description("자식 댓글의 자식 댓글 리스트").optional() // 자식 댓글의 자식 댓글이 없을 수 있으므로 optional로 표시
+                        )
+                ));
+    }
+    private CommentResponse createCommentResponseWithChildren() {
+        CommentResponse parentComment = new CommentResponse(
+                CommentStatus.ACTIVE,
+                1L,
+                "부모 댓글 내용",
+                Instant.now(),
+                new MemberProfileDto("작성자 이름", "/test", "KOREA")
+        );
+
+        CommentResponse childComment1 = new CommentResponse(
+                CommentStatus.ACTIVE,
+                2L,
+                "자식 댓글 내용 1",
+                Instant.now(),
+                new MemberProfileDto("작성자 이름", "/test", "KOREA")
+        );
+
+        CommentResponse childComment2 = new CommentResponse(
+                CommentStatus.ACTIVE,
+                3L,
+                "자식 댓글 내용 2",
+                Instant.now(),
+                new MemberProfileDto("작성자 이름", "/test", "KOREA")
+        );
+
+        parentComment.setChildren(List.of(childComment1, childComment2));
+        return parentComment;
+    }
+
+    private CommentResponse createCommentResponseWithoutChildren() {
+        return new CommentResponse(
+                CommentStatus.ACTIVE,
+                1L,
+                "댓글 내용",
+                Instant.now(),
+                new MemberProfileDto("작성자 이름", "/test", "KOREA"),
+                null
+        );
+    }
+
+    @Test
+    @DisplayName("API - 댓글 삭제")
+    void deleteCommentTest() throws Exception {
+        // Given
+
+        final SuccessResponse<?> response = SuccessResponse.of(CommentSuccess. DELETE_COMMENT_SUCCESS);
+        doReturn(response).when(commentController).deleteComment(any(), any());
+
+        // When & Then
+        mockMvc.perform(delete("/comments?comment-id={id}",1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", GIVEN_ACCESS_TOKEN)
+                )
+                .andExpect(status().isOk())
+
+                .andDo(document("api-delete-child-comment",
+                        queryParameters(
+                                parameterWithName("comment-id").description("댓글 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("응답 결과")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/aliens/backend/docs/GreatRestDocsTest.java
+++ b/src/test/java/com/aliens/backend/docs/GreatRestDocsTest.java
@@ -1,0 +1,107 @@
+package com.aliens.backend.docs;
+
+import com.aliens.backend.board.controller.dto.response.BoardResponse;
+import com.aliens.backend.board.controller.dto.response.MemberProfileDto;
+import com.aliens.backend.board.domain.enums.BoardCategory;
+import com.aliens.backend.global.response.SuccessResponse;
+import com.aliens.backend.global.response.success.CommentSuccess;
+import com.aliens.backend.global.response.success.GreatSuccess;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class GreatRestDocsTest extends BaseRestDocsTest{
+
+    @Test
+    @DisplayName("API - 게시글 좋아요 * 이미 있다면 좋아요 취소")
+    void deleteCommentTest() throws Exception {
+        // Given
+        final SuccessResponse<?> response = SuccessResponse.of(GreatSuccess.GREAT_AT_BOARD_SUCCESS);
+        doReturn(response).when(greatController).greatAtBoard(any(), any());
+
+        // When & Then
+        mockMvc.perform(post("/great?board-id={id}",1)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", GIVEN_ACCESS_TOKEN)
+                )
+                .andExpect(status().isOk())
+
+                .andDo(document("api-great-at-board",
+                        queryParameters(
+                                parameterWithName("board-id").description("게시글 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("응답 결과")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("API - 좋아요한 게시글 조회")
+    void getAllGreatBoardsTest() throws Exception {
+        // Given
+        final List<BoardResponse> boardResponses = List.of(
+                createBoardResponse(),
+                createBoardResponse());
+
+        final SuccessResponse<?> response = SuccessResponse.of(GreatSuccess.GET_ALL_GREAT_BOARDS_SUCCESS, boardResponses);
+        doReturn(response).when(greatController).getAllGreatBoards(any(), any());
+
+        // When & Then
+        mockMvc.perform(get("/great/my-board")
+                        .header("Authorization", GIVEN_ACCESS_TOKEN)
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("api-great-get-my-boards",
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0부터 시작)"),
+                                parameterWithName("size").description("페이지당 아이템 개수")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("내가 작성한 게시글 조회 결과"),
+                                fieldWithPath("result[].id").description("게시글 ID"),
+                                fieldWithPath("result[].category").description("게시글 카테고리"),
+                                fieldWithPath("result[].title").description("게시글 제목"),
+                                fieldWithPath("result[].content").description("게시글 내용"),
+                                fieldWithPath("result[].greatCount").description("게시글 좋아요 수"),
+                                fieldWithPath("result[].commentCount").description("게시글 댓글 수"),
+                                fieldWithPath("result[].imageUrls").description("게시글 이미지 URL 리스트"),
+                                fieldWithPath("result[].createdAt").description("게시글 생성 시간"),
+                                fieldWithPath("result[].memberProfileDto.name").description("게시글 작성자 이름"),
+                                fieldWithPath("result[].memberProfileDto.profileImageUrl").description("게시글 작성자 프로필 이미지 URL"),
+                                fieldWithPath("result[].memberProfileDto.nationality").description("게시글 작성자 국적")
+                        )
+                ));
+    }
+
+    private BoardResponse createBoardResponse() {
+        return new BoardResponse(1L,
+                BoardCategory.FREE,
+                "제목 1",
+                "내용 1",
+                1L,
+                1L,
+                List.of("/test", "/test"),
+                Instant.now(),
+                new MemberProfileDto("작성자 이름", "/test","KOREA")
+        );
+    }
+}

--- a/src/test/java/com/aliens/backend/docs/MarketBoardRestDocsTest.java
+++ b/src/test/java/com/aliens/backend/docs/MarketBoardRestDocsTest.java
@@ -1,0 +1,266 @@
+package com.aliens.backend.docs;
+
+import com.aliens.backend.board.controller.dto.request.MarketChangeRequest;
+import com.aliens.backend.board.controller.dto.request.MarketBoardCreateRequest;
+import com.aliens.backend.board.controller.dto.response.MarketBoardResponse;
+import com.aliens.backend.board.controller.dto.response.MemberProfileDto;
+import com.aliens.backend.board.domain.enums.ProductStatus;
+import com.aliens.backend.board.domain.enums.SaleStatus;
+import com.aliens.backend.global.response.SuccessResponse;
+import com.aliens.backend.global.response.success.MarketBoardSuccess;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MarketBoardRestDocsTest extends BaseRestDocsTest  {
+
+    @Test
+    @DisplayName("API - 장터 게시글 생성")
+    void createMarketBoardTest() throws Exception {
+        // Given
+        MarketBoardCreateRequest request = new MarketBoardCreateRequest(
+                "Title",
+                "Content",
+                SaleStatus.SELL,
+                "10000",
+                ProductStatus.BRAND_NEW);
+        SuccessResponse<?> response = SuccessResponse.of(MarketBoardSuccess.CREATE_MARKET_BOARD_SUCCESS);
+        doReturn(response).when(marketBoardController).createMarketBoard(any(), any(), any());
+
+        MockMultipartFile multipartFile = createMultipartFile();
+
+        // When & Then
+        mockMvc.perform(multipart("/boards/market")
+                        .file("marketBoardImages", multipartFile.getBytes())
+                        .file("marketBoardImages", multipartFile.getBytes())
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+
+                        .header("Authorization", GIVEN_ACCESS_TOKEN))
+
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("market-board-create",
+                        requestParts(
+                                partWithName("marketBoardImages").description("게시물 등록 이미지 파일1"),
+                                partWithName("marketBoardImages").description("게시물 등록 이미지 파일2")
+                        ),
+                        requestFields(
+                                fieldWithPath("title").description("장터 게시물 제목"),
+                                fieldWithPath("content").description("장터 게시물 내용"),
+                                fieldWithPath("saleStatus").description("판매 상태"),
+                                fieldWithPath("price").description("판매 가격"),
+                                fieldWithPath("productStatus").description("상품 상태")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("회원가입 결과")
+                        )
+                ));
+    }
+
+    private MockMultipartFile createMultipartFile() {
+        return new MockMultipartFile("boardImages",
+                "test-image.png",
+                "image/png",
+                "test data".getBytes());
+    }
+
+    @Test
+    @DisplayName("API - 장터 게시글 조회")
+    void getAllBoardsTest() throws Exception {
+        // Given
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        List<MarketBoardResponse> markets = List.of(
+                createMarketBoardResponse(),
+                createMarketBoardResponse());
+
+        SuccessResponse<List<MarketBoardResponse>> response = SuccessResponse.of(MarketBoardSuccess.GET_MARKET_BOARD_PAGE_SUCCESS, markets);
+        doReturn(response).when(marketBoardController).getMarketBoardPage(pageable);
+
+        // When & Then
+        mockMvc.perform(get("/boards/market")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("api-market-board-get-all",
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (0부터 시작)"),
+                                parameterWithName("size").description("페이지당 아이템 개수")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("장터 게시글 조회 결과"),
+                                fieldWithPath("result[].id").description("게시글 ID"),
+                                fieldWithPath("result[].title").description("게시글 제목"),
+                                fieldWithPath("result[].saleStatus").description("판매 상태"),
+                                fieldWithPath("result[].price").description("상품 가격"),
+                                fieldWithPath("result[].productStatus").description("상품 상태"),
+                                fieldWithPath("result[].content").description("게시글 내용"),
+                                fieldWithPath("result[].greatCount").description("게시글 좋아요 수"),
+                                fieldWithPath("result[].commentCount").description("게시글 댓글 수"),
+                                fieldWithPath("result[].commentCount").description("게시글 댓글 수"),
+                                fieldWithPath("result[].imageUrls").description("이미지 파일 주소들"),
+                                fieldWithPath("result[].createdAt").description("게시글 작성 날짜"),
+                                fieldWithPath("result[].memberProfileDto.name").description("게시글 작성자 이름"),
+                                fieldWithPath("result[].memberProfileDto.profileImageUrl").description("게시글 작성자 프로필 이미지 URL"),
+                                fieldWithPath("result[].memberProfileDto.nationality").description("게시글 작성자 국적")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("API - 장터 게시글 상세 조회")
+    void getMarketBoardDetailsTest() throws Exception {
+        // Given
+        MarketBoardResponse market = createMarketBoardResponse();
+
+        SuccessResponse<MarketBoardResponse> response = SuccessResponse.of(MarketBoardSuccess.GET_MARKET_BOARD_DETAILS_SUCCESS, market);
+        doReturn(response).when(marketBoardController).getMarketBoardDetails(1L);
+
+        // When & Then
+        mockMvc.perform(get("/boards/market/details")
+                        .param("id", "1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("api-market-board-get-details",
+                        queryParameters(
+                                parameterWithName("id").description("장터 게시글 id")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("장터 게시글 조회 결과"),
+                                fieldWithPath("result.id").description("게시글 ID"),
+                                fieldWithPath("result.title").description("게시글 제목"),
+                                fieldWithPath("result.saleStatus").description("판매 상태"),
+                                fieldWithPath("result.price").description("상품 가격"),
+                                fieldWithPath("result.productStatus").description("상품 상태"),
+                                fieldWithPath("result.content").description("게시글 내용"),
+                                fieldWithPath("result.greatCount").description("게시글 좋아요 수"),
+                                fieldWithPath("result.commentCount").description("게시글 댓글 수"),
+                                fieldWithPath("result.imageUrls").description("이미지 파일 주소들"),
+                                fieldWithPath("result.createdAt").description("게시글 작성 날짜"),
+                                fieldWithPath("result.memberProfileDto.name").description("게시글 작성자 이름"),
+                                fieldWithPath("result.memberProfileDto.profileImageUrl").description("게시글 작성자 프로필 이미지 URL"),
+                                fieldWithPath("result.memberProfileDto.nationality").description("게시글 작성자 국적")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("API - 장터 게시글 검색")
+    void searchAllBoardPageTest() throws Exception {
+        // Given
+        String searchKeyword = "검색어";
+        List<MarketBoardResponse> markets = List.of(
+                createMarketBoardResponse(),
+                createMarketBoardResponse());
+
+        SuccessResponse<List<MarketBoardResponse>> response = SuccessResponse.of(MarketBoardSuccess.SEARCH_MARKET_BOARD_SUCCESS, markets);
+        doReturn(response).when(marketBoardController).searchMarketBoards(any(), any());
+
+        // When & Then
+        mockMvc.perform(get("/boards/market/search")
+                        .param("search-keyword", searchKeyword)
+                        .param("page", "0")
+                        .param("size", "10")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("api-market-board-search",
+                        queryParameters(
+                                parameterWithName("search-keyword").description("검색어"),
+                                parameterWithName("page").description("페이지 번호 (0부터 시작)"),
+                                parameterWithName("size").description("페이지당 아이템 개수")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("장터 게시글 조회 결과"),
+                                fieldWithPath("result[].id").description("게시글 ID"),
+                                fieldWithPath("result[].title").description("게시글 제목"),
+                                fieldWithPath("result[].saleStatus").description("판매 상태"),
+                                fieldWithPath("result[].price").description("상품 가격"),
+                                fieldWithPath("result[].productStatus").description("상품 상태"),
+                                fieldWithPath("result[].content").description("게시글 내용"),
+                                fieldWithPath("result[].greatCount").description("게시글 좋아요 수"),
+                                fieldWithPath("result[].commentCount").description("게시글 댓글 수"),
+                                fieldWithPath("result[].imageUrls").description("이미지 파일 주소들"),
+                                fieldWithPath("result[].createdAt").description("게시글 작성 날짜"),
+                                fieldWithPath("result[].memberProfileDto.name").description("게시글 작성자 이름"),
+                                fieldWithPath("result[].memberProfileDto.profileImageUrl").description("게시글 작성자 프로필 이미지 URL"),
+                                fieldWithPath("result[].memberProfileDto.nationality").description("게시글 작성자 국적")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("API - 장터 게시글 수정")
+    void changeMarketBoardTest() throws Exception {
+        // Given
+        MarketChangeRequest request = new MarketChangeRequest(
+                "Title",
+                "Content",
+                SaleStatus.SELL,
+                "10000",
+                ProductStatus.BRAND_NEW);
+        SuccessResponse<?> response = SuccessResponse.of(MarketBoardSuccess.CHANGE_MARKET_BOARD_SUCCESS);
+        doReturn(response).when(marketBoardController).changeMarketBoard(any(), any(), any());
+
+
+        // When & Then
+        mockMvc.perform(put("/boards/market")
+                        .param("id", "1")
+                        .content(objectMapper.writeValueAsString(request))
+                        .header("Authorization", GIVEN_ACCESS_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+
+                .andExpect(status().is2xxSuccessful())
+                .andDo(document("market-board-change",
+                        requestFields(
+                                fieldWithPath("title").description("장터 게시물 제목"),
+                                fieldWithPath("content").description("장터 게시물 내용"),
+                                fieldWithPath("saleStatus").description("판매 상태"),
+                                fieldWithPath("price").description("판매 가격"),
+                                fieldWithPath("productStatus").description("상품 상태")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("성공 코드"),
+                                fieldWithPath("result").description("회원가입 결과")
+                        )
+                ));
+    }
+
+    private MarketBoardResponse createMarketBoardResponse() {
+        return new MarketBoardResponse(
+                1L,
+                "title",
+                SaleStatus.SELL,
+                "10000",
+                ProductStatus.ALMOST_NEW,
+                "팔고 있어요",
+                2L,
+                1L,
+                List.of("/test","/test"),
+                Instant.now(),
+                new MemberProfileDto("작성자 이름","/test", "KROEA"));
+    }
+}

--- a/src/test/java/com/aliens/backend/docs/MemberRestDocsTest.java
+++ b/src/test/java/com/aliens/backend/docs/MemberRestDocsTest.java
@@ -33,7 +33,7 @@ class MemberRestDocsTest extends BaseRestDocsTest {
     @DisplayName("API - 회원가입")
     void signUp() throws Exception {
         final SignUpRequest request = createSignUpRequest();
-        MockMultipartFile signUpRequestFile = getSignUpRequestFile(request);
+
         final String message = MemberResponse.SIGN_UP_SUCCESS.getMessage();
         SuccessResponse<String> response = SuccessResponse.of(MemberSuccess.SIGN_UP_SUCCESS, message);
         MockMultipartFile multipartFile = createMultipartFile();
@@ -42,17 +42,26 @@ class MemberRestDocsTest extends BaseRestDocsTest {
 
         // When and Then
         mockMvc.perform(multipart("/members")
-                        .file(signUpRequestFile)
                         .file("profileImage", multipartFile.getBytes())
                         .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON)
-                        .characterEncoding("UTF-8")
+
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andExpect(status().is2xxSuccessful())
                 .andDo(document("member-signup",
                         requestParts(
-                                partWithName("signUpRequest").description("회원가입 요청 데이터"),
                                 partWithName("profileImage").description("프로필 이미지 파일")
+                        ),
+                        requestFields(
+                                fieldWithPath("name").description("이름"),
+                                fieldWithPath("email").description("이메일"),
+                                fieldWithPath("password").description("비밀번호"),
+                                fieldWithPath("mbti").description("MBTI"),
+                                fieldWithPath("gender").description("성별"),
+                                fieldWithPath("nationality").description("국적"),
+                                fieldWithPath("birthday").description("생년월일"),
+                                fieldWithPath("aboutMe").description("자기소개")
                         ),
                         responseFields(
                                 fieldWithPath("code").description("성공 코드"),

--- a/src/test/java/com/aliens/backend/global/BaseIntegrationTest.java
+++ b/src/test/java/com/aliens/backend/global/BaseIntegrationTest.java
@@ -52,6 +52,7 @@ public abstract class BaseIntegrationTest {
         //AWS
         S3File tmpFile = new S3File(DummyGenerator.GIVEN_FILE_NAME,DummyGenerator.GIVEN_FILE_URL);
         doReturn(tmpFile).when(awsS3Uploader).singleUpload(any(MultipartFile.class));
+        doReturn(tmpFile).when(awsS3Uploader).delete(any());
         doReturn(List.of(tmpFile)).when(awsS3Uploader).multiUpload(any());
     }
 }

--- a/src/test/java/com/aliens/backend/global/BaseIntegrationTest.java
+++ b/src/test/java/com/aliens/backend/global/BaseIntegrationTest.java
@@ -52,7 +52,7 @@ public abstract class BaseIntegrationTest {
         //AWS
         S3File tmpFile = new S3File(DummyGenerator.GIVEN_FILE_NAME,DummyGenerator.GIVEN_FILE_URL);
         doReturn(tmpFile).when(awsS3Uploader).singleUpload(any(MultipartFile.class));
-        doReturn(tmpFile).when(awsS3Uploader).delete(any());
+        doReturn(true).when(awsS3Uploader).delete(any());
         doReturn(List.of(tmpFile)).when(awsS3Uploader).multiUpload(any());
     }
 }

--- a/src/test/java/com/aliens/backend/global/DummyGenerator.java
+++ b/src/test/java/com/aliens/backend/global/DummyGenerator.java
@@ -4,6 +4,16 @@ import com.aliens.backend.auth.controller.dto.LoginMember;
 import com.aliens.backend.auth.domain.Member;
 import com.aliens.backend.auth.service.PasswordEncoder;
 import com.aliens.backend.auth.service.TokenProvider;
+import com.aliens.backend.board.controller.dto.request.BoardCreateRequest;
+import com.aliens.backend.board.controller.dto.request.MarketBoardCreateRequest;
+import com.aliens.backend.board.domain.*;
+import com.aliens.backend.board.domain.enums.BoardCategory;
+import com.aliens.backend.board.domain.enums.ProductStatus;
+import com.aliens.backend.board.domain.enums.SaleStatus;
+import com.aliens.backend.board.domain.repository.BoardImageRepository;
+import com.aliens.backend.board.domain.repository.BoardRepository;
+import com.aliens.backend.board.domain.repository.CommentRepository;
+import com.aliens.backend.board.domain.repository.GreatRepository;
 import com.aliens.backend.global.exception.RestApiException;
 import com.aliens.backend.global.property.MatchingTimeProperties;
 import com.aliens.backend.global.response.error.MatchingError;
@@ -17,7 +27,7 @@ import com.aliens.backend.mathcing.business.model.Language;
 import com.aliens.backend.mathcing.service.MatchingProcessService;
 import com.aliens.backend.member.controller.dto.EncodedMember;
 import com.aliens.backend.member.controller.dto.EncodedSignUp;
-import com.aliens.backend.member.domain.Image;
+import com.aliens.backend.member.domain.MemberImage;
 import com.aliens.backend.member.domain.MemberInfo;
 import com.aliens.backend.member.domain.repository.MemberInfoRepository;
 import com.aliens.backend.member.sevice.SymmetricKeyEncoder;
@@ -38,6 +48,11 @@ public class DummyGenerator {
     @Autowired MatchingRoundRepository matchingRoundRepository;
     @Autowired MatchingTimeProperties matchingTimeProperties;
     @Autowired MatchingProcessService matchingProcessService;
+    @Autowired CommentRepository commentRepository;
+    @Autowired GreatRepository greatRepository;
+    @Autowired BoardRepository boardRepository;
+    @Autowired
+    BoardImageRepository boardImageRepository;
     @Autowired PasswordEncoder passwordEncoder;
     @Autowired SymmetricKeyEncoder encoder;
     @Autowired TokenProvider tokenProvider;
@@ -53,6 +68,12 @@ public class DummyGenerator {
     public static final String GIVEN_ABOUT_ME = "nice to meet you";
     public static final String GIVEN_FILE_NAME = "test";
     public static final String GIVEN_FILE_URL = "/test";
+    public static final String GIVEN_BOARD_TITLE = "게시글 제목";
+    public static final String GIVEN_BOARD_CONTENT = "게시글 내용";
+    public static final String GIVEN_COMMENT_CONTENT = "댓글 내용";
+    public static final SaleStatus GIVEN_SALE_STATUS = SaleStatus.SELL;
+    public static final String GIVEN_PRICE = "10000";
+    public static final ProductStatus GIVEN_PRODUCT_STATUS = ProductStatus.ALMOST_NEW;
 
     // 다수 멤버 생성 메서드
     public List<Member> generateMultiMember(Integer memberCounts) {
@@ -60,8 +81,8 @@ public class DummyGenerator {
 
         for (int i = 0; i < memberCounts; i++) {
             String tmpEmail = GIVEN_EMAIL + i;
-            Image image = makeImage();
-            Member member = makeMember(tmpEmail, image);
+            MemberImage memberImage = makeImage();
+            Member member = makeMember(tmpEmail, memberImage);
             result.add(member);
         }
 
@@ -72,8 +93,8 @@ public class DummyGenerator {
     // 단일 멤버 생성 메서드
     public Member generateSingleMember() {
         String tmpEmail = GIVEN_EMAIL;
-        Image image = makeImage();
-        Member member = makeMember(tmpEmail, image);
+        MemberImage memberImage = makeImage();
+        Member member = makeMember(tmpEmail, memberImage);
         saveAsMemberInfo(member);
         return member;
     }
@@ -97,21 +118,20 @@ public class DummyGenerator {
         matchingProcessService.operateMatching();
     }
 
-    private Image makeImage() {
-        return Image.from(new S3File(GIVEN_FILE_NAME, GIVEN_FILE_URL));
+    private MemberImage makeImage() {
+        return MemberImage.from(new S3File(GIVEN_FILE_NAME, GIVEN_FILE_URL));
     }
 
-    private Member makeMember(String email, Image image) {
+    private Member makeMember(String email, MemberImage memberImage) {
         String encodedPassword = passwordEncoder.encrypt(GIVEN_PASSWORD);
-        EncodedSignUp signUp = new EncodedSignUp(GIVEN_NAME, email, encodedPassword);
-        return Member.of(signUp, image);
+        EncodedSignUp signUp = new EncodedSignUp(GIVEN_NAME, email, encodedPassword, GIVEN_NATIONALITY);
+        return Member.of(signUp, memberImage);
     }
 
     private void saveAsMemberInfo(final Member member) {
         EncodedMember encodedRequest = new EncodedMember(encoder.encrypt(GIVEN_GENDER),
                 encoder.encrypt(GIVEN_MBTI),
                 encoder.encrypt(GIVEN_BIRTHDAY),
-                encoder.encrypt(GIVEN_NATIONALITY),
                 encoder.encrypt(GIVEN_ABOUT_ME));
 
         MemberInfo memberInfo = MemberInfo.of(encodedRequest, member);
@@ -158,5 +178,93 @@ public class DummyGenerator {
     private Language getRandomLanguage(Random random) {
         Language[] languages = Language.values();
         return languages[random.nextInt(languages.length)];
+    }
+
+    // 일반 카테고리 게시글 생성
+    public Board generateSingleNormalBoard(final Member member, final BoardCategory category) {
+        BoardCreateRequest request = new BoardCreateRequest(GIVEN_BOARD_TITLE, GIVEN_BOARD_CONTENT, category);
+
+        Board board = Board.normalOf(request, member);
+
+        BoardImage givenBoardImage1 = makeBoardImage(board);
+        BoardImage givenBoardImage2 = makeBoardImage(board);
+        board.setImages(List.of(givenBoardImage1, givenBoardImage2));
+
+        Comment comment = Comment.parentOf(GIVEN_COMMENT_CONTENT, board, member);
+        board.addComment(comment);
+
+        Great great = Great.of(board, member);
+        board.addGreat(great);
+
+        return boardRepository.save(board);
+    }
+
+    // 일반 카테고리 게시글 생성(내용 기입 가능)
+    public Board generateSingleNormalBoard(final Member member, final BoardCategory category, final String content) {
+        BoardCreateRequest request = new BoardCreateRequest(GIVEN_BOARD_TITLE, content, category);
+
+        Board board = Board.normalOf(request, member);
+
+        BoardImage givenBoardImage1 = makeBoardImage(board);
+        BoardImage givenBoardImage2 = makeBoardImage(board);
+        board.setImages(List.of(givenBoardImage1, givenBoardImage2));
+
+        Comment comment = Comment.parentOf(GIVEN_COMMENT_CONTENT, board, member);
+        board.addComment(comment);
+
+        Great great = Great.of(board, member);
+        board.addGreat(great);
+
+        return boardRepository.save(board);
+    }
+
+    // 장터 게시글 생성
+    public Board generateSingleMarketBoard(final Member member) {
+        MarketBoardCreateRequest marketRequest = new MarketBoardCreateRequest(GIVEN_BOARD_TITLE,
+                GIVEN_BOARD_CONTENT, GIVEN_SALE_STATUS, GIVEN_PRICE, GIVEN_PRODUCT_STATUS);
+        MarketInfo givenMarketInfo = MarketInfo.from(marketRequest);
+        BoardCreateRequest boardRequest = BoardCreateRequest.from(marketRequest);
+
+        Board board = Board.marketOf(boardRequest, member, givenMarketInfo);
+
+        BoardImage givenBoardImage1 = makeBoardImage(board);
+        BoardImage givenBoardImage2 = makeBoardImage(board);
+        board.setImages(List.of(givenBoardImage1, givenBoardImage2));
+
+        Comment comment = Comment.parentOf(GIVEN_COMMENT_CONTENT, board, member);
+        board.addComment(comment);
+
+        Great great = Great.of(board, member);
+        board.addGreat(great);
+
+        return boardRepository.save(board);
+    }
+
+    // 장터 게시글 생성(내용 기입 가능)
+    public Board generateSingleMarketBoard(final Member member, final String content) {
+        MarketBoardCreateRequest marketRequest = new MarketBoardCreateRequest(GIVEN_BOARD_TITLE,
+                content, GIVEN_SALE_STATUS, GIVEN_PRICE, GIVEN_PRODUCT_STATUS);
+        MarketInfo givenMarketInfo = MarketInfo.from(marketRequest);
+        BoardCreateRequest boardRequest = BoardCreateRequest.from(marketRequest);
+
+        Board board = Board.marketOf(boardRequest, member, givenMarketInfo);
+
+        BoardImage givenBoardImage1 = makeBoardImage(board);
+        BoardImage givenBoardImage2 = makeBoardImage(board);
+        board.setImages(List.of(givenBoardImage1, givenBoardImage2));
+
+        Comment comment = Comment.parentOf(GIVEN_COMMENT_CONTENT, board, member);
+        board.addComment(comment);
+
+        Great great = Great.of(board, member);
+        board.addGreat(great);
+
+        return boardRepository.save(board);
+    }
+
+    private BoardImage makeBoardImage(Board board) {
+        BoardImage boardImage = BoardImage.from(new S3File(GIVEN_FILE_NAME, GIVEN_FILE_URL));
+        boardImage.setBoard(board);
+        return boardImage;
     }
 }

--- a/src/test/java/com/aliens/backend/global/DummyGenerator.java
+++ b/src/test/java/com/aliens/backend/global/DummyGenerator.java
@@ -51,8 +51,7 @@ public class DummyGenerator {
     @Autowired CommentRepository commentRepository;
     @Autowired GreatRepository greatRepository;
     @Autowired BoardRepository boardRepository;
-    @Autowired
-    BoardImageRepository boardImageRepository;
+    @Autowired BoardImageRepository boardImageRepository;
     @Autowired PasswordEncoder passwordEncoder;
     @Autowired SymmetricKeyEncoder encoder;
     @Autowired TokenProvider tokenProvider;


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #85 
- #29 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- 게시판 읽기에 쓰이는 쿼리에서,  검색 시 10개가 적용되던 쿼리를 2개로 줄였습니다. 
- 알림 기능은 다른 피처에서 작업하고자합니다. 
- doc 테스트는 작성했으나, adoc이 작성되지 않았습니다. 다른 피처에서 작업하도록 할 예정입니다. 

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 테스트 144개 모두 성공했습니다. 
<img width="574" alt="image" src="https://github.com/Re-4aliens/backend/assets/86913355/41fab0ca-1b4c-49ec-8fdd-ea5247b98119">

- ORM에서 자동 작성되는 쿼리문을 다시 봐야할 필요성을 느꼈습니다.
의도치 않게 작성되는 쿼리나, 원하지 않은 열들을 가져오는 쿼리가 생기더군요.
새로운 이슈를 하나 만들어서 해당 문제를 추후에 살펴 보고자합니다. 