### PR TITLE
Feat/#36 채팅 도메인 리펙토링, 테스트 커버리지 향상

### DIFF
--- a/src/docs/asciidoc/block.adoc
+++ b/src/docs/asciidoc/block.adoc
@@ -1,0 +1,23 @@
+= Spring REST Docs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+[[resources-chat]]
+== Report
+
+=== 채팅 상대 차단
+
+==== HTTP request
+
+include::{snippets}/chat-block/http-request.adoc[]
+
+==== request-body 설명
+include::{snippets}/chat-block/request-fields.adoc[]
+
+==== HTTP response
+
+include::{snippets}/chat-block/http-response.adoc[]
+
+==== response-body 설명
+include::{snippets}/chat-block/response-fields.adoc[]

--- a/src/docs/asciidoc/chat.adoc
+++ b/src/docs/asciidoc/chat.adoc
@@ -1,0 +1,216 @@
+= Spring REST Docs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+[[resources-chat]]
+== Chat
+
+=== 메시지 조회
+
+==== HTTP request
+
+include::{snippets}/chat-get-messages/http-request.adoc[]
+
+==== request-body 설명
+include::{snippets}/chat-get-messages/path-parameters.adoc[]
+
+==== HTTP response
+
+include::{snippets}/chat-get-messages/http-response.adoc[]
+
+==== response-body 설명
+include::{snippets}/chat-get-messages/response-fields.adoc[]
+
+=== 채팅방 요약 정보 조회
+
+==== HTTP request
+
+include::{snippets}/chat-get-summaries/http-request.adoc[]
+
+==== HTTP response
+
+include::{snippets}/chat-get-summaries/http-response.adoc[]
+
+==== response-body 설명
+include::{snippets}/chat-get-summaries/response-fields.adoc[]
+
+
+[[resources-websocket]]
+== Chat - 웹소켓
+
+아래부터는 웹소켓을 통한 채팅 기능에 대해 설명합니다.
+
+=== 웹소켓 연결 요청
+
+==== STOMP - CONNECT
+[source,http]
+----
+CONNECT /ws STOMP
+Authorization: <access_token>
+----
+[cols="1,1,3"]
+|===
+| Header | Type | Description
+
+| Authorization
+| String
+| 사용자 인증을 위한 JWT 토큰(access token)
+
+|===
+
+=== 웹소켓 구독 요청
+
+==== STOMP - SUBSCRIBE
+[source,http]
+----
+SUBSCRIBE /room/{roomId} STOMP
+----
+[cols="1,1,3"]
+|===
+| Destination | Type | Description
+
+| roomId
+| String
+| 구독할 채팅방의 ID(ex: /room/101)
+
+|===
+
+
+=== 메시지 전송 요청
+==== STOMP - SEND
+[source,http]
+----
+SEND /chat/send STOMP
+content-type: application/json
+
+{
+  "type": "NORMAL",
+  "content": "안녕하세요",
+  "roomId": 1,
+  "senderId": 1,
+  "receiverId": 2
+}
+----
+
+==== Payload 설명
+[cols="1,1,3"]
+|===
+| Field | Type | Description
+
+| type
+| String
+| 메시지 타입(NORMAL, BALANCE_GAME)
+
+| content
+| String
+| 메시지 내용
+
+| roomId
+| Number
+| 메시지를 전송할 채팅방의 ID
+
+| senderId
+| Number
+| 메시지를 전송하는 사용자의 ID
+
+| receiverId
+| Number
+| 메시지를 수신하는 사용자의 ID
+
+|===
+
+=== 읽음 처리 요청
+
+==== STOMP - SEND
+[source,http]
+----
+SEND /chat/send STOMP
+content-type: application/json
+
+{
+  "roomId": 1,
+  "memberId": 1
+}
+----
+
+==== Payload 설명
+[cols="1,1,3"]
+|===
+| Field | Type | Description
+
+| roomId
+| Number
+| 읽음 처리를 요청하는 채팅방의 ID
+
+| memberId
+| Number
+| 읽음 처리를 요청하는 사용자의 ID
+|===
+
+=== 구독 후 메시지 수신
+[source,http]
+----
+Payload
+content-type: application/json
+{
+    "id": "1",
+    "type": "NORMAL",
+    "content": "안녕하세요",
+    "roomId": 1,
+    "senderId": 1,
+    "receiverId": 2,
+    "timestamp": "2021-01-01T00:00:00.000Z"
+    "isRead": false
+}
+----
+[cols="1,1,3"]
+|===
+| Field | Type | Description
+
+| id
+| String
+| 메시지 ID
+
+| type
+| String
+| 메시지 유형 (NORMAL, BALANCE_GAME 등)
+
+| content
+| String
+| 메시지 내용
+
+| roomId
+| Number
+| 메시지가 속한 채팅방 ID
+
+| senderId
+| Number
+| 메시지를 보낸 사용자의 ID
+
+| receiverId
+| Number
+| 메시지를 받은 사용자의 ID
+
+| timestamp
+| String
+| 메시지가 전송된 시각
+
+| isRead
+| Boolean
+| 메시지를 읽었는지 여부
+|===
+
+=== 구독 후 읽음 처리 메시지 수신
+[source,http]
+----
+Payload
+content-type: application/json
+{
+    "readBy": 1
+}
+----
+[cols="1,1,3"]
+|===
+| Field | Type | Description
+| readBy | Number | 읽음 처리를 요청한 사용자의 ID

--- a/src/docs/asciidoc/report.adoc
+++ b/src/docs/asciidoc/report.adoc
@@ -1,0 +1,23 @@
+= Spring REST Docs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+[[resources-chat]]
+== Report
+
+=== 채팅 상대 신고
+
+==== HTTP request
+
+include::{snippets}/chat-report/http-request.adoc[]
+
+==== request-body 설명
+include::{snippets}/chat-report/request-fields.adoc[]
+
+==== HTTP response
+
+include::{snippets}/chat-report/http-response.adoc[]
+
+==== response-body 설명
+include::{snippets}/chat-report/response-fields.adoc[]

--- a/src/main/java/com/aliens/backend/chat/domain/Message.java
+++ b/src/main/java/com/aliens/backend/chat/domain/Message.java
@@ -11,7 +11,6 @@ import java.util.Date;
 public class Message {
     @Id
     private String id;
-
     private MessageType type;
     private String content;
     private Long roomId;
@@ -33,6 +32,38 @@ public class Message {
         message.sendTime = new Date();
         message.isRead = false;
         return message;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public MessageType getType() {
+        return type;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Long getRoomId() {
+        return roomId;
+    }
+
+    public Long getSenderId() {
+        return senderId;
+    }
+
+    public Long getReceiverId() {
+        return receiverId;
+    }
+
+    public Date getSendTime() {
+        return sendTime;
+    }
+
+    public Boolean getIsRead() {
+        return isRead;
     }
 
     @Override

--- a/src/main/java/com/aliens/backend/chat/service/ChatAuthValidator.java
+++ b/src/main/java/com/aliens/backend/chat/service/ChatAuthValidator.java
@@ -1,16 +1,22 @@
 package com.aliens.backend.chat.service;
 
 import com.aliens.backend.chat.domain.ChatRoom;
-import com.aliens.backend.global.response.error.ChatError;
 import com.aliens.backend.global.exception.RestApiException;
+import com.aliens.backend.global.response.error.ChatError;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 @Component
 public class ChatAuthValidator {
-    public void validateRoom(String topic, List<ChatRoom> validChatRooms) {
+    public void validateRoomFromTopic(String topic, List<ChatRoom> validChatRooms) {
         Long roomId = getRoomIdFromTopic(topic);
+        if(!isValidRoom(validChatRooms, roomId)) {
+            throw new RestApiException(ChatError.INVALID_ROOM_ACCESS);
+        }
+    }
+
+    public void validateRoom(Long roomId, List<ChatRoom> validChatRooms) {
         if(!isValidRoom(validChatRooms, roomId)) {
             throw new RestApiException(ChatError.INVALID_ROOM_ACCESS);
         }

--- a/src/main/java/com/aliens/backend/chat/service/ChatAuthValidator.java
+++ b/src/main/java/com/aliens/backend/chat/service/ChatAuthValidator.java
@@ -27,6 +27,6 @@ public class ChatAuthValidator {
     }
 
     private long getRoomIdFromTopic(String topic) {
-        return Long.parseLong(topic.split("/")[1]);
+        return Long.parseLong(topic.split("/")[2]);
     }
 }

--- a/src/main/java/com/aliens/backend/chat/service/ChatService.java
+++ b/src/main/java/com/aliens/backend/chat/service/ChatService.java
@@ -38,9 +38,9 @@ public class ChatService {
 
     public String sendMessage(MessageSendRequest messageSendRequest) {
         Message message = Message.of(messageSendRequest);
-        saveMessage(message);
-        publishMessage(message, messageSendRequest.roomId());
-        sendNotification(message);
+        Message savedMessage = saveMessage(message);
+        publishMessage(savedMessage, messageSendRequest.roomId());
+        sendNotification(savedMessage);
         return ChatSuccess.SEND_MESSAGE_SUCCESS.getMessage();
     }
 
@@ -67,8 +67,8 @@ public class ChatService {
         return chatRoomRepository.findByMemberId(memberId);
     }
 
-    private void saveMessage(Message message) {
-        messageRepository.save(message);
+    private Message saveMessage(Message message) {
+        return messageRepository.save(message);
     }
 
     private void publishMessage(Message message, Long ChatRoomId) {

--- a/src/main/java/com/aliens/backend/global/config/interceptor/ChatChannelInterceptor.java
+++ b/src/main/java/com/aliens/backend/global/config/interceptor/ChatChannelInterceptor.java
@@ -1,8 +1,12 @@
 package com.aliens.backend.global.config.interceptor;
 
 import com.aliens.backend.chat.controller.dto.request.MessageSendRequest;
+import com.aliens.backend.chat.controller.dto.request.ReadRequest;
 import com.aliens.backend.chat.domain.ChatRoom;
 import com.aliens.backend.chat.service.ChatAuthValidator;
+import com.aliens.backend.global.property.WebSocketProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
@@ -18,23 +22,34 @@ import java.util.List;
 public class ChatChannelInterceptor implements ChannelInterceptor {
 
     private final ChatAuthValidator chatAuthValidator;
+    private final WebSocketProperties properties;
+    private final Logger logger = LoggerFactory.getLogger("웹소켓 요청");
 
     private MappingJackson2MessageConverter messageConverter = new MappingJackson2MessageConverter();
 
-    public ChatChannelInterceptor(ChatAuthValidator chatAuthValidator) {
+    public ChatChannelInterceptor(ChatAuthValidator chatAuthValidator, WebSocketProperties properties) {
         this.chatAuthValidator = chatAuthValidator;
+        this.properties = properties;
     }
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        logger.info("preSend: {} - {}",accessor.getCommand(), accessor.getDestination());
+
         List<ChatRoom> chatRooms = (List<ChatRoom>) accessor.getSessionAttributes().get("chatRooms");
         if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
             chatAuthValidator.validateRoomFromTopic(accessor.getDestination(), chatRooms);
         }
-        if (StompCommand.SEND.equals(accessor.getCommand()) && accessor.getDestination().equals("/chatting/send")) {
-            MessageSendRequest messageSendRequest = (MessageSendRequest) messageConverter.fromMessage(message, MessageSendRequest.class);
-            chatAuthValidator.validateRoom(messageSendRequest.roomId(), chatRooms);
+        if(StompCommand.SEND.equals(accessor.getCommand())){
+            if(accessor.getDestination().equals(properties.getAppDestinationPrefix() +"/send")){
+                MessageSendRequest messageSendRequest = (MessageSendRequest) messageConverter.fromMessage(message, MessageSendRequest.class);
+                chatAuthValidator.validateRoom(messageSendRequest.roomId(), chatRooms);
+            }
+            if(accessor.getDestination().equals(properties.getAppDestinationPrefix() +"/read")){
+                ReadRequest readRequest = (ReadRequest) messageConverter.fromMessage(message, ReadRequest.class);
+                chatAuthValidator.validateRoom(readRequest.roomId(), chatRooms);
+            }
         }
         return message;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,4 +16,4 @@ websocket:
   port: 8080
   endpoint: /ws
   topic: /room
-  request: /chatting
+  request: /chat

--- a/src/test/java/com/aliens/backend/chat/domain/ChatParticipantTest.java
+++ b/src/test/java/com/aliens/backend/chat/domain/ChatParticipantTest.java
@@ -1,0 +1,26 @@
+package com.aliens.backend.chat.domain;
+
+import com.aliens.backend.auth.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+
+class ChatParticipantTest {
+        @Test
+        @DisplayName("ChatParticipant 생성 테스트")
+        void CreateChatParticipant() {
+            //given
+            ChatRoom chatRoom = new ChatRoom();
+            Member member = mock(Member.class);
+            Member partner = mock(Member.class);
+
+            //when
+            ChatParticipant chatParticipant = ChatParticipant.of(chatRoom, member, partner);
+
+            //then
+            assertNotNull(chatParticipant);
+        }
+}

--- a/src/test/java/com/aliens/backend/chat/domain/ChatRoomTest.java
+++ b/src/test/java/com/aliens/backend/chat/domain/ChatRoomTest.java
@@ -1,0 +1,61 @@
+package com.aliens.backend.chat.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+class ChatRoomTest {
+
+    @Test
+    @DisplayName("ChatRoom 생성 테스트")
+    public void CreateChatRoom() {
+        // given
+        ChatParticipant participant1 = mock(ChatParticipant.class);
+        ChatParticipant participant2 = mock(ChatParticipant.class);
+
+        // when
+        ChatRoom chatRoom = new ChatRoom(participant1, participant2);
+
+        // then
+        assertNotNull(chatRoom);
+        assertEquals(ChatRoomStatus.WAITING, chatRoom.getStatus());
+    }
+
+    @Test
+    @DisplayName("ChatRoom id 반환 테스트")
+    public void GetId() throws NoSuchFieldException, IllegalAccessException {
+        // given
+        Long givenId = 1L;
+        ChatRoom chatRoom = new ChatRoom();
+
+        Field idField = ChatRoom.class.getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(chatRoom, givenId);
+
+        // when
+        Long actualId = chatRoom.getId();
+
+        // then
+        assertEquals(givenId, actualId);
+    }
+
+    @Test
+    @DisplayName("ChatRoom 차단 테스트")
+    public void Block() {
+        // given
+        ChatParticipant participant1 = mock(ChatParticipant.class);
+        ChatParticipant participant2 = mock(ChatParticipant.class);
+        ChatRoom chatRoom = new ChatRoom(participant1, participant2);
+
+        // when
+        chatRoom.block();
+
+        // then
+        assertEquals(ChatRoomStatus.BLOCKED, chatRoom.getStatus());
+    }
+}

--- a/src/test/java/com/aliens/backend/chat/domain/MessageTest.java
+++ b/src/test/java/com/aliens/backend/chat/domain/MessageTest.java
@@ -1,0 +1,56 @@
+package com.aliens.backend.chat.domain;
+
+import com.aliens.backend.chat.controller.dto.request.MessageSendRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MessageTest {
+
+    @Test
+    @DisplayName("Message 생성 테스트")
+    void CreateMessage() {
+        // given
+        MessageSendRequest messageSendRequest = new MessageSendRequest(
+                MessageType.NORMAL,
+                "content",
+                1L,
+                1L,
+                2L
+        );
+
+        // when
+        Message message = Message.of(messageSendRequest);
+
+        // then
+        assertNotNull(message);
+    }
+
+    @Test
+    @DisplayName("Message toString 테스트")
+    void ToString() {
+        // given
+        MessageSendRequest messageSendRequest = new MessageSendRequest(
+                MessageType.NORMAL,
+                "content",
+                1L,
+                1L,
+                2L
+        );
+        Message message = Message.of(messageSendRequest);
+
+        // when
+        String result = message.toString();
+
+        // then
+        assertTrue(result.contains("id"));
+        assertTrue(result.contains("type"));
+        assertTrue(result.contains("content"));
+        assertTrue(result.contains("roomId"));
+        assertTrue(result.contains("senderId"));
+        assertTrue(result.contains("receiverId"));
+        assertTrue(result.contains("sendTime"));
+        assertTrue(result.contains("isRead"));
+    }
+}

--- a/src/test/java/com/aliens/backend/chat/domain/MessageTypeTest.java
+++ b/src/test/java/com/aliens/backend/chat/domain/MessageTypeTest.java
@@ -1,0 +1,36 @@
+package com.aliens.backend.chat.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MessageTypeTest {
+    @Test
+    @DisplayName("MessageType fromString 테스트")
+    void FromString() {
+        // given
+        String type = "NORMAL";
+
+        // when
+        Optional<MessageType> result = MessageType.fromString(type);
+
+        // then
+        assertEquals(MessageType.NORMAL, result.get());
+    }
+
+    @Test
+    @DisplayName("MessageType fromString - 잘못된 type")
+    void FromString_InvalidType() {
+        // given
+        String type = "INVALID";
+
+        // when
+        Optional<MessageType> result = MessageType.fromString(type);
+
+        // then
+        assertTrue(result.isEmpty());
+    }
+}

--- a/src/test/java/com/aliens/backend/chatting/socket/WebSocketTest.java
+++ b/src/test/java/com/aliens/backend/chatting/socket/WebSocketTest.java
@@ -3,6 +3,7 @@ package com.aliens.backend.chatting.socket;
 import com.aliens.backend.auth.domain.Member;
 import com.aliens.backend.chat.controller.dto.request.MessageSendRequest;
 import com.aliens.backend.chat.controller.dto.request.ReadRequest;
+import com.aliens.backend.chat.domain.ChatRoom;
 import com.aliens.backend.chat.domain.MessageType;
 import com.aliens.backend.global.BaseIntegrationTest;
 import com.aliens.backend.global.DummyGenerator;
@@ -14,6 +15,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.stomp.StompSession;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.mockito.Mockito.*;
 
@@ -28,10 +32,11 @@ class WebSocketTest extends BaseIntegrationTest {
     private ChatClient chatClient;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private String accessToken ;
+    private Member member;
 
     @BeforeEach
     void setup() {
-        Member member = dummyGenerator.generateSingleMember();
+        member = dummyGenerator.generateSingleMember();
         accessToken = dummyGenerator.generateAccessToken(member);
         chatClient = new ChatClient(properties);
     }
@@ -50,15 +55,49 @@ class WebSocketTest extends BaseIntegrationTest {
     @DisplayName("Websocket - 메시지 전송 요청시 sendMessage() 호출")
     void WebSocketSendMessage() throws Exception {
         //Given
+        ChatRoom chatroom = mock(ChatRoom.class);
+        when(chatroom.getId()).thenReturn(1L);
+        List<ChatRoom> chatRooms = new ArrayList<>();
+        chatRooms.add(chatroom);
+        when(chatService.getChatRooms(member.getId())).thenReturn(chatRooms);
+
+
         StompSession session = chatClient.connect(accessToken);
-        MessageSendRequest messageSendRequest = makeMessageSendRequest();
+        MessageSendRequest messageSendRequest = createMessageSendRequest();
         String jsonMessage = objectMapper.writeValueAsString(messageSendRequest);
 
         //When
         session.send(properties.getAppDestinationPrefix()+"/send", jsonMessage.getBytes());
 
         //Then
+        verify(chatChannelInterceptor, timeout(100).times(2)).preSend(any(), any()); // 1. SUBSCRIBE, 2. SEND
+        verify(chatService, timeout(100).times(1)).getChatRooms(member.getId());
+        verify(chatAuthValidator, timeout(100).times(1)).validateRoom(any(), any());
         verify(chatController, timeout(100).times(1)).sendMessage(messageSendRequest);
+    }
+
+    @Test
+    @DisplayName("Websocket - 메시지 전송 요청시 허가 되지 않은 채팅방 요청")
+    void WebSocketSendMessageWithUnauthorizedRoom() throws Exception {
+        //Given - 허가되지 않은 채팅방 요청
+        ChatRoom chatroom = mock(ChatRoom.class);
+        when(chatroom.getId()).thenReturn(2L);
+        List<ChatRoom> chatRooms = new ArrayList<>();
+        chatRooms.add(chatroom);
+        when(chatService.getChatRooms(member.getId())).thenReturn(chatRooms);
+
+        StompSession session = chatClient.connect(accessToken);
+        MessageSendRequest messageSendRequest = createMessageSendRequest();
+        String jsonMessage = objectMapper.writeValueAsString(messageSendRequest);
+
+        //When
+        session.send(properties.getAppDestinationPrefix()+"/send", jsonMessage.getBytes());
+
+        //Then
+        verify(chatChannelInterceptor, timeout(100).times(3)).preSend(any(), any()); // 1. SUBSCRIBE, 2. SEND, 3. DISCONNECT
+        verify(chatService, timeout(100).times(1)).getChatRooms(member.getId());
+        verify(chatAuthValidator, timeout(100).times(1)).validateRoom(any(), any());
+        verify(chatController, timeout(100).times(0)).sendMessage(messageSendRequest); // 호출되지 않음
     }
 
     @Test
@@ -78,7 +117,7 @@ class WebSocketTest extends BaseIntegrationTest {
         verify(chatController, timeout(100).times(1)).readMessage(readRequest);
     }
 
-    private MessageSendRequest makeMessageSendRequest() {
+    private MessageSendRequest createMessageSendRequest() {
         MessageType type = MessageType.NORMAL;
         String content = "Hello";
         Long roomId = 1L;

--- a/src/test/java/com/aliens/backend/chatting/socket/WebSocketTest.java
+++ b/src/test/java/com/aliens/backend/chatting/socket/WebSocketTest.java
@@ -3,7 +3,9 @@ package com.aliens.backend.chatting.socket;
 import com.aliens.backend.auth.domain.Member;
 import com.aliens.backend.chat.controller.dto.request.MessageSendRequest;
 import com.aliens.backend.chat.controller.dto.request.ReadRequest;
+import com.aliens.backend.chat.controller.dto.response.ReadResponse;
 import com.aliens.backend.chat.domain.ChatRoom;
+import com.aliens.backend.chat.domain.Message;
 import com.aliens.backend.chat.domain.MessageType;
 import com.aliens.backend.global.BaseIntegrationTest;
 import com.aliens.backend.global.DummyGenerator;
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.stomp.StompSession;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,20 +28,22 @@ class WebSocketTest extends BaseIntegrationTest {
 
     @Autowired
     private WebSocketProperties properties;
-
     @Autowired
-    DummyGenerator dummyGenerator;
-
+    private DummyGenerator dummyGenerator;
     private ChatClient chatClient;
-    private final ObjectMapper objectMapper = new ObjectMapper();
-    private String accessToken ;
+    private ObjectMapper objectMapper;
+    private String accessToken;
     private Member member;
+    private Long authorizedRoomId;
 
     @BeforeEach
     void setup() {
         member = dummyGenerator.generateSingleMember();
         accessToken = dummyGenerator.generateAccessToken(member);
         chatClient = new ChatClient(properties);
+        objectMapper = new ObjectMapper();
+        authorizedRoomId = 101L;
+        setValidRooms();
     }
 
     @Test
@@ -52,78 +57,138 @@ class WebSocketTest extends BaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("Websocket - 메시지 전송 요청시 sendMessage() 호출")
-    void WebSocketSendMessage() throws Exception {
-        //Given
-        ChatRoom chatroom = mock(ChatRoom.class);
-        when(chatroom.getId()).thenReturn(1L);
-        List<ChatRoom> chatRooms = new ArrayList<>();
-        chatRooms.add(chatroom);
-        when(chatService.getChatRooms(member.getId())).thenReturn(chatRooms);
-
-
-        StompSession session = chatClient.connect(accessToken);
-        MessageSendRequest messageSendRequest = createMessageSendRequest();
-        String jsonMessage = objectMapper.writeValueAsString(messageSendRequest);
+    @DisplayName("Websocket - 메시지 전송 및 수신 테스트")
+    void WebSocketMessageSendingAndReceiving() throws Exception {
+        // Given
+        MessageSendRequest messageSendRequest = createMessageSendRequest(authorizedRoomId);
+        Message expectedMessage = Message.of(messageSendRequest);
+        setPrivateField(expectedMessage, "id", "507f1f77bcf86cd799439011");
+        doReturn(expectedMessage).when(messageRepository).save(any());
 
         //When
-        session.send(properties.getAppDestinationPrefix()+"/send", jsonMessage.getBytes());
+        chatClient.connect(accessToken);
+        List<Object> receiveMessage = chatClient.subscribe(authorizedRoomId);
+        chatClient.send(properties.getAppDestinationPrefix() + "/send", messageSendRequest);
 
         //Then
-        verify(chatChannelInterceptor, timeout(100).times(2)).preSend(any(), any()); // 1. SUBSCRIBE, 2. SEND
-        verify(chatService, timeout(100).times(1)).getChatRooms(member.getId());
-        verify(chatAuthValidator, timeout(100).times(1)).validateRoom(any(), any());
-        verify(chatController, timeout(100).times(1)).sendMessage(messageSendRequest);
+        verify(chatService, timeout(100).times(1)).sendMessage(messageSendRequest);
+        verify(chatChannelInterceptor, timeout(100).times(3)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND
+        verify(chatService, timeout(100).times(1)).getChatRooms(member.getId()); // CONNECT
+        verify(chatAuthValidator, timeout(100).times(1)).validateRoomFromTopic(any(), any()); // SUBSCRIBE
+        verify(chatAuthValidator, timeout(100).times(1)).validateRoom(any(), any()); // SEND
+        Message receivedMessage = objectMapper.readValue((byte[]) receiveMessage.get(0), Message.class);
+        Assertions.assertEquals(1, receiveMessage.size());
+        Assertions.assertEquals(expectedMessage.getId(), receivedMessage.getId());
+        Assertions.assertEquals(expectedMessage.getType(), receivedMessage.getType());
+        Assertions.assertEquals(expectedMessage.getContent(), receivedMessage.getContent());
+        Assertions.assertEquals(expectedMessage.getRoomId(), receivedMessage.getRoomId());
+        Assertions.assertEquals(expectedMessage.getSenderId(), receivedMessage.getSenderId());
+        Assertions.assertEquals(expectedMessage.getReceiverId(), receivedMessage.getReceiverId());
     }
 
     @Test
     @DisplayName("Websocket - 메시지 전송 요청시 허가 되지 않은 채팅방 요청")
     void WebSocketSendMessageWithUnauthorizedRoom() throws Exception {
-        //Given - 허가되지 않은 채팅방 요청
-        ChatRoom chatroom = mock(ChatRoom.class);
-        when(chatroom.getId()).thenReturn(2L);
-        List<ChatRoom> chatRooms = new ArrayList<>();
-        chatRooms.add(chatroom);
-        when(chatService.getChatRooms(member.getId())).thenReturn(chatRooms);
-
-        StompSession session = chatClient.connect(accessToken);
-        MessageSendRequest messageSendRequest = createMessageSendRequest();
-        String jsonMessage = objectMapper.writeValueAsString(messageSendRequest);
+        //Given
+        Long unAuthorizedRoomId = 102L;
+        MessageSendRequest messageSendRequest = createMessageSendRequest(unAuthorizedRoomId);
 
         //When
-        session.send(properties.getAppDestinationPrefix()+"/send", jsonMessage.getBytes());
+        chatClient.connect(accessToken);
+        chatClient.subscribe(authorizedRoomId);
+        chatClient.send(properties.getAppDestinationPrefix() + "/send", messageSendRequest);
 
         //Then
-        verify(chatChannelInterceptor, timeout(100).times(3)).preSend(any(), any()); // 1. SUBSCRIBE, 2. SEND, 3. DISCONNECT
+        verify(chatChannelInterceptor, timeout(100).times(4)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND, 4. DISCONNECT
         verify(chatService, timeout(100).times(1)).getChatRooms(member.getId());
         verify(chatAuthValidator, timeout(100).times(1)).validateRoom(any(), any());
         verify(chatController, timeout(100).times(0)).sendMessage(messageSendRequest); // 호출되지 않음
     }
 
     @Test
-    @DisplayName("Websocket - 읽음 처리 요청 시 readMessage() 호출")
-    void WebSocketReadMessage() throws Exception {
+    @DisplayName("Websocket - 채팅방 구독 요청시 허가 되지 않은 채팅방 요청")
+    void WebSocketSubscribeWithUnauthorizedRoom() throws Exception {
         //Given
-        Long chatRoomId = 1L;
-        Long memberId = 1L;
-        ReadRequest readRequest = new ReadRequest(chatRoomId, memberId);
-        String jsonMessage = objectMapper.writeValueAsString(readRequest);
-        StompSession session = chatClient.connect(accessToken);
+        Long unAuthorizedRoomId = 102L;
 
         //When
-        session.send(properties.getAppDestinationPrefix()+"/read", jsonMessage.getBytes());
+        chatClient.connect(accessToken);
+        chatClient.subscribe(unAuthorizedRoomId);
 
         //Then
-        verify(chatController, timeout(100).times(1)).readMessage(readRequest);
+        verify(chatChannelInterceptor, timeout(100).times(3)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. DISCONNECT
+        verify(chatService, timeout(100).times(1)).getChatRooms(member.getId());
+        verify(chatAuthValidator, timeout(100).times(1)).validateRoomFromTopic(any(), any());
     }
 
-    private MessageSendRequest createMessageSendRequest() {
+    @Test
+    @DisplayName("Websocket - 읽음 처리 요청")
+    void WebSocketReadMessage() throws Exception {
+        //Given
+        ReadRequest readRequest = new ReadRequest(authorizedRoomId, member.getId());
+        ReadResponse readResponse = new ReadResponse(member.getId());
+        doNothing().when(messageRepository).markMessagesAsRead(any(), any());
+
+        //When
+        chatClient.connect(accessToken);
+        List<Object> receiveMessage = chatClient.subscribe(authorizedRoomId);
+        chatClient.send(properties.getAppDestinationPrefix() + "/read", readRequest);
+
+        //Then
+        verify(chatChannelInterceptor, timeout(100).times(3)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND
+        verify(chatController, timeout(100).times(1)).readMessage(readRequest);
+        verify(chatService, timeout(100).times(1)).getChatRooms(member.getId()); // CONNECT
+        verify(chatAuthValidator, timeout(100).times(1)).validateRoomFromTopic(any(), any()); // SUBSCRIBE
+        verify(chatAuthValidator, timeout(100).times(1)).validateRoom(any(), any()); // SEND
+        ReadResponse receivedReadResponse = objectMapper.readValue((byte[]) receiveMessage.get(0), ReadResponse.class);
+        Assertions.assertEquals(1, receiveMessage.size());
+        Assertions.assertEquals(readResponse.readBy(), receivedReadResponse.readBy());
+    }
+
+    @Test
+    @DisplayName("Websocket - 읽음 처리 요청 시 허가되지 않은 채팅방 요청")
+    void WebSocketReadMessageWithUnauthorizedRoom() throws Exception {
+        //Given
+        Long unAuthorizedRoomId = 102L;
+        ReadRequest unAuthorizedReadRequest = new ReadRequest(unAuthorizedRoomId, member.getId());
+        doNothing().when(messageRepository).markMessagesAsRead(any(), any());
+
+        //When
+        chatClient.connect(accessToken);
+        chatClient.subscribe(authorizedRoomId);
+        chatClient.send(properties.getAppDestinationPrefix() + "/read", unAuthorizedReadRequest);
+
+        //Then
+        verify(chatChannelInterceptor, timeout(100).times(4)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND, 4. DISCONNECT
+        verify(chatService, timeout(100).times(1)).getChatRooms(member.getId());
+        verify(chatAuthValidator, timeout(100).times(1)).validateRoom(any(), any());
+        verify(chatController, timeout(100).times(0)).readMessage(unAuthorizedReadRequest); // 호출되지 않음
+    }
+
+    private MessageSendRequest createMessageSendRequest(Long roomId) {
         MessageType type = MessageType.NORMAL;
         String content = "Hello";
-        Long roomId = 1L;
         Long senderId = 1L;
         Long receiverId = 2L;
         MessageSendRequest messageSendRequest = new MessageSendRequest(type, content, roomId, senderId, receiverId);
         return messageSendRequest;
+    }
+
+    private void setValidRooms() {
+        ChatRoom chatroom = mock(ChatRoom.class);
+        when(chatroom.getId()).thenReturn(authorizedRoomId);
+        List<ChatRoom> chatRooms = new ArrayList<>();
+        chatRooms.add(chatroom);
+        when(chatService.getChatRooms(member.getId())).thenReturn(chatRooms);
+    }
+
+    public void setPrivateField(Object targetObject, String fieldName, Object value) {
+        try {
+            Field field = targetObject.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(targetObject, value);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/com/aliens/backend/docs/BlockRestDocsTest.java
+++ b/src/test/java/com/aliens/backend/docs/BlockRestDocsTest.java
@@ -12,8 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
@@ -43,9 +42,13 @@ class BlockRestDocsTest extends BaseRestDocsTest {
                 )
                 .andExpect(status().isOk())
                 .andDo(document("chat-block",
+                        requestFields(
+                                fieldWithPath("partnerId").description("차단 대상자의 ID"),
+                                fieldWithPath("chatRoomId").description("채팅방의 ID, 차단이 발생한 채팅방")
+                        ),
                         responseFields(
                                 fieldWithPath("code").description("응답 코드"),
-                                fieldWithPath("result").description("채팅 상대 차단 결과")
+                                fieldWithPath("result").description("채팅 상대 차단 결과 메시지")
                         )
                 ));
     }

--- a/src/test/java/com/aliens/backend/docs/ChatRestDocsTest.java
+++ b/src/test/java/com/aliens/backend/docs/ChatRestDocsTest.java
@@ -1,21 +1,29 @@
 package com.aliens.backend.docs;
 
+import com.aliens.backend.chat.controller.dto.request.MessageSendRequest;
 import com.aliens.backend.chat.controller.dto.response.ChatSummaryResponse;
+import com.aliens.backend.chat.domain.ChatRoom;
+import com.aliens.backend.chat.domain.ChatRoomStatus;
 import com.aliens.backend.chat.domain.Message;
+import com.aliens.backend.chat.domain.MessageType;
+import com.aliens.backend.chat.service.model.ChatMessageSummary;
 import com.aliens.backend.global.response.SuccessResponse;
 import com.aliens.backend.global.response.success.ChatSuccess;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class ChatRestDocsTest extends BaseRestDocsTest {
@@ -24,18 +32,35 @@ class ChatRestDocsTest extends BaseRestDocsTest {
     @DisplayName("API - 채팅 메시지 조회")
     void getMessages() throws Exception {
         Long chatRoomId = 1L;
-        List<Message> result = new ArrayList<>();
+        MessageSendRequest request1 = new MessageSendRequest(MessageType.NORMAL, "first message", chatRoomId, 101L, 102L);
+        MessageSendRequest request2 = new MessageSendRequest(MessageType.NORMAL, "Second message", chatRoomId, 101L, 102L);
+
+        Message message1 = Message.of(request1);
+        Message message2 = Message.of(request2);
+
+        List<Message> result = Arrays.asList(message1, message2);
+
         SuccessResponse<List<Message>> response = SuccessResponse.of(ChatSuccess.GET_MESSAGES_SUCCESS, result);
         doReturn(response).when(chatController).getMessages(any(),any());
 
         mockMvc.perform(get("/chat/room/{roomId}/messages", chatRoomId)
-                        .header("Authorization", GIVEN_ACCESS_TOKEN)
-                )
+                        .header("Authorization", GIVEN_ACCESS_TOKEN))
                 .andExpect(status().isOk())
                 .andDo(document("chat-get-messages",
+                        pathParameters(
+                                parameterWithName("roomId").description("채팅방의 ID")
+                        ),
                         responseFields(
                                 fieldWithPath("code").description("응답 코드"),
-                                fieldWithPath("result").description("메시지 목록 조회 결과")
+                                fieldWithPath("result").description("메시지 목록 조회 결과"),
+                                fieldWithPath("result[].id").description("메시지 ID"),
+                                fieldWithPath("result[].type").description("메시지 유형"),
+                                fieldWithPath("result[].content").description("메시지 내용"),
+                                fieldWithPath("result[].roomId").description("채팅방 ID"),
+                                fieldWithPath("result[].senderId").description("메시지를 보낸 사용자의 ID"),
+                                fieldWithPath("result[].receiverId").description("메시지를 받은 사용자의 ID"),
+                                fieldWithPath("result[].sendTime").description("메시지가 보내진 시간"),
+                                fieldWithPath("result[].isRead").description("메시지 읽음 상태 (true: 읽음, false: 읽지 않음)")
                         )
                 ));
     }
@@ -43,8 +68,25 @@ class ChatRestDocsTest extends BaseRestDocsTest {
     @Test
     @DisplayName("API - 채팅 요약 정보 조회")
     void getChatSummary() throws Exception {
-        ChatSummaryResponse result = new ChatSummaryResponse(new ArrayList<>(), new ArrayList<>());
+        List<ChatRoom> chatRooms = new ArrayList<>();
+        ChatRoom chatRoom1 = mock(ChatRoom.class);
+        when(chatRoom1.getId()).thenReturn(1L);
+        when(chatRoom1.getStatus()).thenReturn(ChatRoomStatus.OPEN);
+        ChatRoom chatRoom2 = mock(ChatRoom.class);
+        when(chatRoom2.getId()).thenReturn(2L);
+        when(chatRoom2.getStatus()).thenReturn(ChatRoomStatus.OPEN);
+        chatRooms.add(chatRoom1);
+        chatRooms.add(chatRoom2);
+
+        List<ChatMessageSummary> chatMessageSummaries = List.of(
+                new ChatMessageSummary(1L, "Last message in Room 1", 5L),
+                new ChatMessageSummary(2L, "Last message in Room 2", 3L)
+        );
+
+        ChatSummaryResponse result = new ChatSummaryResponse(chatRooms, chatMessageSummaries);
+
         SuccessResponse<ChatSummaryResponse> response = SuccessResponse.of(ChatSuccess.GET_SUMMARIES_SUCCESS, result);
+
         doReturn(response).when(chatController).getChatSummaries(any());
 
 
@@ -52,12 +94,16 @@ class ChatRestDocsTest extends BaseRestDocsTest {
                         .header("Authorization", GIVEN_ACCESS_TOKEN)
                 )
                 .andExpect(status().isOk())
-                .andDo(document("chat-get-summary",
+                .andDo(document("chat-get-summaries",
                         responseFields(
                                 fieldWithPath("code").description("응답 코드"),
-                                fieldWithPath("result").description("조회 결과"),
-                                fieldWithPath("result.chatRooms").description("채팅방 정보"),
-                                fieldWithPath("result.chatMessageSummaries").description("채팅방 요약 정보 조회 결과")
+                                fieldWithPath("result.chatRooms").description("사용자가 속한 채팅방 목록"),
+                                fieldWithPath("result.chatRooms[].id").description("채팅방의 ID"),
+                                fieldWithPath("result.chatRooms[].status").description("채팅방의 상태"),
+                                fieldWithPath("result.chatMessageSummaries").description("각 채팅방의 요약 정보"),
+                                fieldWithPath("result.chatMessageSummaries[].roomId").description("채팅방 ID"),
+                                fieldWithPath("result.chatMessageSummaries[].lastMessageContent").description("채팅방의 마지막 메시지 내용"),
+                                fieldWithPath("result.chatMessageSummaries[].numberOfUnreadMessages").description("읽지 않은 메시지의 수")
                         )
                 ));
     }

--- a/src/test/java/com/aliens/backend/docs/ReportRestDocsTest.java
+++ b/src/test/java/com/aliens/backend/docs/ReportRestDocsTest.java
@@ -11,8 +11,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
@@ -38,9 +37,15 @@ class ReportRestDocsTest extends BaseRestDocsTest {
                 )
                 .andExpect(status().isOk())
                 .andDo(document("chat-report",
+                        requestFields(
+                                fieldWithPath("partnerId").description("신고 대상자의 ID"),
+                                fieldWithPath("chatRoomId").description("채팅방의 ID, 신고가 발생한 채팅방"),
+                                fieldWithPath("category").description("신고 카테고리: SEXUAL_HARASSMENT, VIOLENCE, SPAM, SCAM, ETC"),
+                                fieldWithPath("content").description("신고 내용, 신고 대상자의 행동에 대한 설명")
+                        ),
                         responseFields(
                                 fieldWithPath("code").description("응답 코드"),
-                                fieldWithPath("result").description("채팅 상대 신고 결과")
+                                fieldWithPath("result").description("채팅 상대 신고 결과 메시지")
                         )
                 ));
     }

--- a/src/test/java/com/aliens/backend/event/EventPublisherTest.java
+++ b/src/test/java/com/aliens/backend/event/EventPublisherTest.java
@@ -3,6 +3,7 @@ package com.aliens.backend.event;
 import com.aliens.backend.auth.domain.Member;
 import com.aliens.backend.chat.controller.dto.event.ChatRoomBlockEvent;
 import com.aliens.backend.chat.controller.dto.event.ChatRoomCreationEvent;
+import com.aliens.backend.chat.domain.ChatRoom;
 import com.aliens.backend.chat.service.model.MemberPair;
 import com.aliens.backend.global.BaseIntegrationTest;
 import com.aliens.backend.global.DummyGenerator;
@@ -16,11 +17,11 @@ import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 class EventPublisherTest extends BaseIntegrationTest {
@@ -81,7 +82,8 @@ class EventPublisherTest extends BaseIntegrationTest {
     void handleChatRoomBlockEventTest() {
         // Given
         ChatRoomBlockEvent event = new ChatRoomBlockEvent(givenChatRoomId);
-        doNothing().when(chatService).handleChatRoomBlockEvent(event);
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        doReturn(Optional.of(chatRoom)).when(chatRoomRepository).findById(givenChatRoomId);
 
         // When
         publisher.publishEvent(event);

--- a/src/test/java/com/aliens/backend/global/BaseIntegrationTest.java
+++ b/src/test/java/com/aliens/backend/global/BaseIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.aliens.backend.global;
 
 import com.aliens.backend.chat.controller.ChatController;
+import com.aliens.backend.chat.domain.repository.ChatRoomRepository;
 import com.aliens.backend.chat.domain.repository.MessageRepository;
 import com.aliens.backend.chat.service.ChatAuthValidator;
 import com.aliens.backend.chat.service.ChatService;
@@ -34,6 +35,7 @@ public abstract class BaseIntegrationTest {
     @SpyBean protected FcmSender fcmSender;
     // 수정 예정
     @SpyBean protected MessageRepository messageRepository;
+    @SpyBean protected ChatRoomRepository chatRoomRepository;
     @SpyBean protected ChatService chatService;
     @SpyBean protected ChatController chatController;
     @SpyBean protected ChatChannelInterceptor chatChannelInterceptor;

--- a/src/test/java/com/aliens/backend/global/BaseIntegrationTest.java
+++ b/src/test/java/com/aliens/backend/global/BaseIntegrationTest.java
@@ -2,7 +2,9 @@ package com.aliens.backend.global;
 
 import com.aliens.backend.chat.controller.ChatController;
 import com.aliens.backend.chat.domain.repository.MessageRepository;
+import com.aliens.backend.chat.service.ChatAuthValidator;
 import com.aliens.backend.chat.service.ChatService;
+import com.aliens.backend.global.config.interceptor.ChatChannelInterceptor;
 import com.aliens.backend.notification.FcmSender;
 import com.aliens.backend.uploader.AwsS3Uploader;
 import com.aliens.backend.uploader.dto.S3File;
@@ -34,6 +36,8 @@ public abstract class BaseIntegrationTest {
     @SpyBean protected MessageRepository messageRepository;
     @SpyBean protected ChatService chatService;
     @SpyBean protected ChatController chatController;
+    @SpyBean protected ChatChannelInterceptor chatChannelInterceptor;
+    @SpyBean protected ChatAuthValidator chatAuthValidator;
 
     @Autowired private DatabaseCleanup databaseCleanUp;
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -17,3 +17,6 @@ spring:
     console:
       enabled: true
       path: /h2-console
+  data:
+    mongodb:
+      uri: mongodb://localhost:27017/database?serverSelectionTimeoutMS=1000


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #36
- #60 
- #48

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- restDocs 추가, 웹소켓 파트 수기 작성
- 읽기 요청시 인증 로직 추가
- 테스트 커버리지 향상 72% -> 92%
- 웹소켓 테스트를 연결, 구독, 요청, 수신까지 통합 과정으로 테스트 수정
- mongoDB Timeout 설정으로 테스트 종료시간 지연 제거

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 
