### PR TITLE
Refactor/#91 INSERT 쿼리 전, SELECT 쿼리가 나가는 문제 

### DIFF
--- a/src/main/java/com/aliens/backend/global/response/error/MatchingError.java
+++ b/src/main/java/com/aliens/backend/global/response/error/MatchingError.java
@@ -8,6 +8,7 @@ public enum MatchingError implements ErrorCode {
     NOT_FOUND_MATCHING_APPLICATION_INFO(HttpStatus.NOT_FOUND, "MA3", "매칭 신청 정보 찾을 수 없음"),
     NOT_FOUND_PREFER_LANGUAGE(HttpStatus.NOT_FOUND, "MA4", "선호 언어를 찾을 수 없음"),
     INVALID_LANGUAGE_INPUT(HttpStatus.BAD_REQUEST, "MA5", "두 선호 언어가 같을 수 없음"),
+    DUPLICATE_MATCHING_APPLICATION(HttpStatus.BAD_REQUEST, "MA6", "중복된 매칭 신청"),
 
     ;
 

--- a/src/main/java/com/aliens/backend/mathcing/domain/MatchingApplication.java
+++ b/src/main/java/com/aliens/backend/mathcing/domain/MatchingApplication.java
@@ -59,6 +59,10 @@ public class MatchingApplication {
         this.secondPreferLanguage = matchingApplicationRequest.secondPreferLanguage();
     }
 
+    public MatchingApplicationId getId() {
+        return id;
+    }
+
     public Member getMember() {
         return id.getMember();
     }
@@ -84,4 +88,3 @@ public class MatchingApplication {
                 '}';
     }
 }
-

--- a/src/main/java/com/aliens/backend/mathcing/domain/MatchingResult.java
+++ b/src/main/java/com/aliens/backend/mathcing/domain/MatchingResult.java
@@ -6,9 +6,10 @@ import com.aliens.backend.mathcing.business.model.Partner;
 import com.aliens.backend.mathcing.domain.id.MatchingResultId;
 import com.aliens.backend.mathcing.business.model.Relationship;
 import jakarta.persistence.*;
+import org.springframework.data.domain.Persistable;
 
 @Entity
-public class MatchingResult {
+public class MatchingResult implements Persistable<MatchingResultId> {
     @EmbeddedId
     private MatchingResultId id;
 
@@ -65,5 +66,15 @@ public class MatchingResult {
 
     public Relationship getRelationship() {
         return relationship;
+    }
+
+    @Override
+    public MatchingResultId getId() {
+        return id;
+    }
+
+    @Override
+    public boolean isNew() {
+        return true;
     }
 }

--- a/src/main/java/com/aliens/backend/mathcing/service/MatchingApplicationService.java
+++ b/src/main/java/com/aliens/backend/mathcing/service/MatchingApplicationService.java
@@ -95,6 +95,7 @@ public class MatchingApplicationService {
     }
 
     private void applyForMatching(MatchingApplication matchingApplication) {
+        checkDuplicateApply(matchingApplication);
         matchingApplicationRepository.save(matchingApplication);
         Member member = matchingApplication.getMember();
         member.applyMatch();
@@ -109,6 +110,12 @@ public class MatchingApplicationService {
     private void checkReceptionTime(MatchingRound matchingRound) {
         if (!matchingRound.isReceptionTime(LocalDateTime.now(clock))) {
             throw new RestApiException(MatchingError.NOT_VALID_MATCHING_RECEPTION_TIME);
+        }
+    }
+
+    private void checkDuplicateApply(MatchingApplication matchingApplication) {
+        if (matchingApplicationRepository.existsById(matchingApplication.getId())) {
+            throw new RestApiException(MatchingError.DUPLICATE_MATCHING_APPLICATION);
         }
     }
 }

--- a/src/test/java/com/aliens/backend/matching/unit/service/MatchingApplicationServiceTest.java
+++ b/src/test/java/com/aliens/backend/matching/unit/service/MatchingApplicationServiceTest.java
@@ -71,6 +71,17 @@ class MatchingApplicationServiceTest extends BaseIntegrationTest {
     }
 
     @Test
+    @DisplayName("매칭 중복 신청 테스트")
+    void duplicateMatchApply() {
+        // given
+        matchingApplicationService.saveParticipant(loginMember, matchingApplicationRequest);
+
+        // when, then
+        assertThatThrownBy(() -> matchingApplicationService.saveParticipant(loginMember, matchingApplicationRequest))
+                .hasMessage(MatchingError.DUPLICATE_MATCHING_APPLICATION.getDevelopCode());
+    }
+
+    @Test
     @DisplayName("매칭 신청 정보 수정 테스트")
     void modifyMatchingApplicationTest() {
         // given


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #91 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- MatchingResult 엔티티 클래스에 Persistable<>의 isNew 메서드를 true로 변경하여 
INSERT 쿼리를 보내기 전, SELECT 쿼리가 나가는 문제를 해결했습니다. 
- 또한, 매칭 신청을 보내기 이전, 중복된 매칭신청인지 확인하는 코드가 빠져있어 추가로 구현했습니다. 

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 회차별로 매칭 결과는 단한번만 저장되므로, 중복되어 저장될 일이 없어 SELECT로 이미 해당 결과가 있는지 확인할 필요가 없습니다. 
따라서, SELECT로 한번 더 확인할 필요 없이 바로 INSERT 하도록 isNew 메서드를 true로 Override했습니다.
