### PR TITLE
2024-05-06[HotFix] 이미지 업로드 시, 잘못된 타입 확인 변경

### DIFF
--- a/src/main/java/com/aliens/backend/uploader/AwsS3Uploader.java
+++ b/src/main/java/com/aliens/backend/uploader/AwsS3Uploader.java
@@ -23,6 +23,9 @@ public class AwsS3Uploader {
     private final S3UploadProperties s3UploadProperties;
 
     private static final String SUFFIX = ".png";
+    private static final String PNJ_FILE_EXTENSION = "png";
+    private static final String JPEG_FILE_EXTENSION = "jpeg";
+    private static final String GIF_FILE_EXTENSION = "gif";
     private static final int MAX_UPLOADS = 2;
     private static final long MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10 MB
 
@@ -33,7 +36,6 @@ public class AwsS3Uploader {
     }
 
     public List<S3File> multiUpload(List<MultipartFile> files) {
-
         checkFileSize(files);
         return files.stream().map(this::uploadToS3).toList();
     }
@@ -69,12 +71,11 @@ public class AwsS3Uploader {
 
         return new S3File(uuidName,amazonS3Client.getUrl(s3UploadProperties.getBucket(),uuidName).toString());
     }
-
     private void checkFilesImage(final MultipartFile multipartFile) {
-        String contentType = multipartFile.getContentType();
-        if(contentType == null
-                || (!contentType.equals(MediaType.IMAGE_JPEG_VALUE)
-                && !contentType.equals(MediaType.IMAGE_PNG_VALUE))) {
+        String extension = StringUtils.getFilenameExtension(multipartFile.getOriginalFilename());
+        if (!extension.equalsIgnoreCase(PNJ_FILE_EXTENSION)
+                && !extension.equalsIgnoreCase(JPEG_FILE_EXTENSION)
+                && !extension.equalsIgnoreCase(GIF_FILE_EXTENSION)) {
             throw new RestApiException(BoardError.POST_IMAGE_ERROR);
         }
     }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #107

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- 기존에 이미지 확장자를 잘못 확인하고 있어 이미지 업로드시 실패가 떴습니다. 이를 JPG, JPEG, GIF 만을 확장자로 허용하도록 합니다. 

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 
