### PR TITLE
created date 수정, 파일 확장자 추가, 불필요한 쿼리 수정

### DIFF
--- a/src/main/java/com/aliens/backend/auth/domain/Member.java
+++ b/src/main/java/com/aliens/backend/auth/domain/Member.java
@@ -10,7 +10,6 @@ import com.aliens.backend.member.domain.MemberInfo;
 import com.aliens.backend.member.domain.MatchingStatus;
 import com.aliens.backend.member.controller.dto.EncodedSignUp;
 import com.aliens.backend.member.sevice.SymmetricKeyEncoder;
-import com.aliens.backend.notification.domain.FcmToken;
 import com.aliens.backend.uploader.dto.S3File;
 import jakarta.persistence.*;
 
@@ -54,14 +53,12 @@ public class Member {
     private List<Token> tokens = new ArrayList<>();
 
     @OneToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE})
-    @JoinColumn(name = "imageId")
+    @JoinColumn(name = "memberImageId")
     private MemberImage memberImage;
 
-    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberInfoId")
     private MemberInfo memberInfo;
-
-    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private FcmToken fcmToken;
 
     protected Member() {
     }

--- a/src/main/java/com/aliens/backend/board/controller/BoardController.java
+++ b/src/main/java/com/aliens/backend/board/controller/BoardController.java
@@ -43,34 +43,34 @@ public class BoardController {
     }
 
     @GetMapping
-    public SuccessResponse<List<BoardResponse>> getAllBoards(@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    public SuccessResponse<List<BoardResponse>> getAllBoards(@PageableDefault(sort = "boardId", direction = Sort.Direction.DESC) Pageable pageable) {
         return SuccessResponse.of(BoardSuccess.GET_ALL_BOARDS_SUCCESS,
                 boardReadService.getBoardPage(pageable));
     }
 
     @GetMapping("/category")
     public SuccessResponse<List<BoardResponse>> getAllBoardsWithCategory(@RequestParam final String category,
-                                                                         @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+                                                                         @PageableDefault(sort = "boardId", direction = Sort.Direction.DESC) final Pageable pageable) {
         return SuccessResponse.of(BoardSuccess.GET_ALL_BOARDS_WITH_CATEGORY_SUCCESS,
                 boardReadService.getBoardPageWithCategory(category,pageable));
     }
 
     @GetMapping("/search")
     public SuccessResponse<List<BoardResponse>> searchAllBoardPage(@RequestParam("search-keyword") final String searchKeyword,
-                                                                   @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+                                                                   @PageableDefault(sort = "boardId", direction = Sort.Direction.DESC) final Pageable pageable) {
         return SuccessResponse.of(BoardSuccess.SEARCH_ALL_BOARDS_SUCCESS,
                 boardReadService.searchBoardPageWithKeyword(searchKeyword,pageable));
     }
 
     @GetMapping("/announcements")
-    public SuccessResponse<List<BoardResponse>> getAllAnnouncementBoards(@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+    public SuccessResponse<List<BoardResponse>> getAllAnnouncementBoards(@PageableDefault(sort = "boardId", direction = Sort.Direction.DESC) final Pageable pageable) {
         return SuccessResponse.of(BoardSuccess.GET_ALL_ANNOUNCEMENT_BOARDS_SUCCESS,
                 boardReadService.getAnnouncePage(pageable));
     }
 
     @GetMapping("/writes")
     public SuccessResponse<List<BoardResponse>> getPageMyBoards(@Login LoginMember loginMember,
-                                                                @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+                                                                @PageableDefault(sort = "boardId", direction = Sort.Direction.DESC) final Pageable pageable) {
         return SuccessResponse.of(BoardSuccess.GET_MY_BOARD_PAGE_SUCCESS,
                 boardReadService.getMyBoardPage(loginMember, pageable));
     }
@@ -78,7 +78,7 @@ public class BoardController {
     @GetMapping("/category/search")
     public SuccessResponse<List<BoardResponse>> searchBoardsWithCategory(@RequestParam("search-keyword") final String searchKeyword,
                                                                          @RequestParam("category") final String category,
-                                                                         @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+                                                                         @PageableDefault(sort = "boardId", direction = Sort.Direction.DESC) final Pageable pageable) {
         return SuccessResponse.of(BoardSuccess.SEARCH_BOARD_WITH_CATEGORY_SUCCESS,
                 boardReadService.searchBoardPageWithKeywordAndCategory(searchKeyword, category, pageable));
     }

--- a/src/main/java/com/aliens/backend/board/domain/Board.java
+++ b/src/main/java/com/aliens/backend/board/domain/Board.java
@@ -8,12 +8,14 @@ import com.aliens.backend.board.controller.dto.response.MarketBoardResponse;
 import com.aliens.backend.board.domain.enums.BoardCategory;
 import jakarta.persistence.*;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 public class Board {
 
     @Id

--- a/src/main/java/com/aliens/backend/board/domain/Comment.java
+++ b/src/main/java/com/aliens/backend/board/domain/Comment.java
@@ -7,10 +7,12 @@ import com.aliens.backend.board.domain.enums.CommentStatus;
 import com.aliens.backend.board.domain.enums.CommentType;
 import jakarta.persistence.*;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.Instant;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 public class Comment {
 
     @Id

--- a/src/main/java/com/aliens/backend/chat/service/ChatService.java
+++ b/src/main/java/com/aliens/backend/chat/service/ChatService.java
@@ -109,7 +109,7 @@ public class ChatService {
     }
 
     private String findFcmTokenByMember(Member receiver) {
-        return fcmTokenRepository.findByMember(receiver).getToken();
+        return fcmTokenRepository.findByMember(receiver).get().getToken();
     }
 
     private void updateReadState(Long chatRoomId, Long readBy) {

--- a/src/main/java/com/aliens/backend/member/domain/MemberImage.java
+++ b/src/main/java/com/aliens/backend/member/domain/MemberImage.java
@@ -1,6 +1,5 @@
 package com.aliens.backend.member.domain;
 
-import com.aliens.backend.auth.domain.Member;
 import com.aliens.backend.uploader.dto.S3File;
 import jakarta.persistence.*;
 
@@ -16,10 +15,6 @@ public class MemberImage {
 
     @Column
     String url;
-
-    @OneToOne
-    @JoinColumn(name = "memberId")
-    private Member member;
 
     protected MemberImage() {
     }

--- a/src/main/java/com/aliens/backend/member/domain/MemberInfo.java
+++ b/src/main/java/com/aliens/backend/member/domain/MemberInfo.java
@@ -4,18 +4,14 @@ import com.aliens.backend.auth.domain.Member;
 import com.aliens.backend.member.controller.dto.EncodedMember;
 import com.aliens.backend.member.controller.dto.EncodedMemberPage;
 import jakarta.persistence.*;
+import org.springframework.data.domain.Persistable;
 
 @Entity
-public class MemberInfo {
+public class MemberInfo implements Persistable<Long> {
 
     @Id
     @Column(name = "memberInfoId")
     private Long id;
-
-    @MapsId
-    @OneToOne(cascade = {CascadeType.PERSIST,CascadeType.MERGE})
-    @JoinColumn(name = "memberId")
-    private Member member;
 
     @Column
     private String mbti;
@@ -34,7 +30,7 @@ public class MemberInfo {
 
     public static MemberInfo of(EncodedMember request, Member member) {
         MemberInfo memberInfo = new MemberInfo();
-        memberInfo.member =member;
+        memberInfo.id = member.getId();
         memberInfo.gender = request.gender();
         memberInfo.mbti = request.mbti();
         memberInfo.birthday = request.birthday();
@@ -52,5 +48,19 @@ public class MemberInfo {
 
     public EncodedMemberPage getMemberPage() {
         return new EncodedMemberPage(mbti,gender,birthday,aboutMe);
+    }
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public boolean isNew() {
+        return true;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
     }
 }

--- a/src/main/java/com/aliens/backend/notification/domain/FcmTokenRepository.java
+++ b/src/main/java/com/aliens/backend/notification/domain/FcmTokenRepository.java
@@ -4,7 +4,9 @@ import com.aliens.backend.auth.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
-    FcmToken findByMember(Member member);
+    Optional<FcmToken> findByMember(Member member);
 }

--- a/src/main/java/com/aliens/backend/notification/domain/Notification.java
+++ b/src/main/java/com/aliens/backend/notification/domain/Notification.java
@@ -6,9 +6,11 @@ import com.aliens.backend.notification.controller.dto.NotificationRequest;
 import com.aliens.backend.notification.controller.dto.NotificationResponse;
 import jakarta.persistence.*;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.Instant;
 
+@EntityListeners(AuditingEntityListener.class)
 @Entity
 public class Notification {
 

--- a/src/main/java/com/aliens/backend/notification/service/NotificationService.java
+++ b/src/main/java/com/aliens/backend/notification/service/NotificationService.java
@@ -44,7 +44,7 @@ public class NotificationService {
     @Transactional
     public void registerFcmToken(final LoginMember loginMember, final String fcmToken) {
         Member member = getMember(loginMember.memberId());
-        Optional<FcmToken> optionalFcmToken = fcmTokenRepository.findById(loginMember.memberId());
+        Optional<FcmToken> optionalFcmToken = fcmTokenRepository.findByMember(member);
 
         if (optionalFcmToken.isPresent()) {
             FcmToken fcmTokenEntity = optionalFcmToken.get();

--- a/src/main/java/com/aliens/backend/uploader/AwsS3Uploader.java
+++ b/src/main/java/com/aliens/backend/uploader/AwsS3Uploader.java
@@ -26,6 +26,7 @@ public class AwsS3Uploader {
     private static final String PNJ_FILE_EXTENSION = "png";
     private static final String JPEG_FILE_EXTENSION = "jpeg";
     private static final String GIF_FILE_EXTENSION = "gif";
+    private static final String JPG_FILE_EXTENSION = "jpg";
     private static final int MAX_UPLOADS = 2;
     private static final long MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10 MB
 
@@ -75,7 +76,9 @@ public class AwsS3Uploader {
         String extension = StringUtils.getFilenameExtension(multipartFile.getOriginalFilename());
         if (!extension.equalsIgnoreCase(PNJ_FILE_EXTENSION)
                 && !extension.equalsIgnoreCase(JPEG_FILE_EXTENSION)
-                && !extension.equalsIgnoreCase(GIF_FILE_EXTENSION)) {
+                && !extension.equalsIgnoreCase(GIF_FILE_EXTENSION)
+                && !extension.equalsIgnoreCase(JPG_FILE_EXTENSION)
+        ) {
             throw new RestApiException(BoardError.POST_IMAGE_ERROR);
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   jpa:
-    show_sql: true
+    show_sql: false
     hibernate:
       ddl-auto: none
       naming:

--- a/src/test/java/com/aliens/backend/docs/BoardRestDocsTest.java
+++ b/src/test/java/com/aliens/backend/docs/BoardRestDocsTest.java
@@ -82,7 +82,7 @@ class BoardRestDocsTest extends BaseRestDocsTest {
     @DisplayName("API - 전체 게시글 조회")
     void getAllBoardsTest() throws Exception {
         // Given
-        final Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        final Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "boardId"));
         final List<BoardResponse> boardResponses = List.of(
                 createBoardResponse(),
                 createBoardResponse());

--- a/src/test/java/com/aliens/backend/global/DummyGenerator.java
+++ b/src/test/java/com/aliens/backend/global/DummyGenerator.java
@@ -3,6 +3,7 @@ package com.aliens.backend.global;
 import com.aliens.backend.auth.controller.dto.LoginMember;
 import com.aliens.backend.auth.domain.Member;
 import com.aliens.backend.auth.domain.Token;
+import com.aliens.backend.auth.domain.repository.MemberRepository;
 import com.aliens.backend.auth.domain.repository.TokenRepository;
 import com.aliens.backend.auth.service.PasswordEncoder;
 import com.aliens.backend.auth.service.TokenProvider;
@@ -50,6 +51,7 @@ import java.util.Random;
 
 @Component
 public class DummyGenerator {
+    @Autowired MemberRepository memberRepository;
     @Autowired MatchingApplicationService matchingApplicationService;
     @Autowired MemberInfoRepository memberInfoRepository;
     @Autowired MatchingRoundRepository matchingRoundRepository;
@@ -140,7 +142,7 @@ public class DummyGenerator {
     private Member makeMember(String email, MemberImage memberImage) {
         String encodedPassword = passwordEncoder.encrypt(GIVEN_PASSWORD);
         EncodedSignUp signUp = new EncodedSignUp(GIVEN_NAME, email, encodedPassword, GIVEN_NATIONALITY);
-        return Member.of(signUp, memberImage);
+        return memberRepository.save(Member.of(signUp, memberImage));
     }
 
     private void saveAsMemberInfo(final Member member) {
@@ -151,6 +153,9 @@ public class DummyGenerator {
 
         MemberInfo memberInfo = MemberInfo.of(encodedRequest, member);
         memberInfoRepository.save(memberInfo);
+
+        member.putMemberInfo(memberInfo);
+        memberRepository.save(member);
     }
 
     // MultipartFile 생성 메서드


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #129 
- #125 
- #123 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
-  회원관련 조회에서 불필요한 쿼리를 없앴습니다. (게시판 조회시 쿼리 하나로 감소, 회원 관련 조회시 쿼리 하나로 감소)
- 회원 이미지, 게시판 이미지 등록시 jpg 확장자 가진 파일 업로드를 허용하였습니다.
- createdAt 컬럼에서 MySQL 명령어로 현재시간을 넣어주던 것을 @CreatedDate가 동작하도록 수정했습니다., 
- 게시글 조회시 createdAt 기준이 아닌 pk인 boardId기준으로 정렬된 조회가 가능하도록 수정했습니다. 
- MemberInfo가 MapId로 Member의 id값을 할당 받았기 때문에 즉시로딩이 의도치 않게 지속되었습니다 .이를 지연로딩이 되도록 해결하였습니다. 
## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 이전에 3개의 쿼리가 나가던 게시판 조회를 1개로 줄였습니다..!!!
- Member 조회에도 추가적으로 나가던 MemberInfo 쿼리가 지연로딩이 동작할 수 있게끔 수정했습니다. 🙋‍♂️ 
