### PR TITLE
Feat/#136 채팅 만료 이벤트 핸들러 추가

### DIFF
--- a/src/main/java/com/aliens/backend/chat/controller/dto/event/ChatRoomExpireEvent.java
+++ b/src/main/java/com/aliens/backend/chat/controller/dto/event/ChatRoomExpireEvent.java
@@ -1,8 +1,4 @@
 package com.aliens.backend.chat.controller.dto.event;
 
-import com.aliens.backend.chat.service.model.MemberPair;
-
-import java.util.Set;
-
-public record ChatRoomExpireEvent(Set<MemberPair> matchedPairs) {
+public record ChatRoomExpireEvent() {
 }

--- a/src/main/java/com/aliens/backend/chat/domain/ChatRoomStatus.java
+++ b/src/main/java/com/aliens/backend/chat/domain/ChatRoomStatus.java
@@ -1,5 +1,5 @@
 package com.aliens.backend.chat.domain;
 
 public enum ChatRoomStatus {
-    WAITING, OPEN, CLOSE, BLOCKED;
+    WAITING, OPENED, CLOSED, BLOCKED;
 }

--- a/src/main/java/com/aliens/backend/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/aliens/backend/chat/domain/repository/ChatRoomRepository.java
@@ -2,6 +2,7 @@ package com.aliens.backend.chat.domain.repository;
 
 import com.aliens.backend.chat.domain.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +12,8 @@ import java.util.List;
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     @Query("SELECT c FROM ChatRoom c JOIN c.participants p WHERE p.member.id = :memberId")
     List<ChatRoom> findByMemberId(Long memberId);
+
+    @Modifying
+    @Query("UPDATE ChatRoom c SET c.status = com.aliens.backend.chat.domain.ChatRoomStatus.CLOSED")
+    void expireAllChatRooms();
 }

--- a/src/main/java/com/aliens/backend/chat/service/ChatService.java
+++ b/src/main/java/com/aliens/backend/chat/service/ChatService.java
@@ -154,6 +154,17 @@ public class ChatService {
         chatRoomRepository.save(chatRoom);
     }
 
+    @EventListener
+    @Transactional
+    public void handleChatRoomExpireEvent(ChatRoomExpireEvent chatRoomExpireEvent) {
+        expireAllChatRooms();
+    }
+
+    private void expireAllChatRooms() {
+        chatRoomRepository.expireAllChatRooms();
+        chatParticipantRepository.deleteAll();
+    }
+
     private ChatRoom findChatRoomsById(final Long chatRoomId) {
         return chatRoomRepository.findById(chatRoomId).orElseThrow(() -> new RestApiException(ChatError.CHAT_ROOM_NOT_FOUND));
     }

--- a/src/main/java/com/aliens/backend/chat/service/ChatService.java
+++ b/src/main/java/com/aliens/backend/chat/service/ChatService.java
@@ -5,6 +5,7 @@ import com.aliens.backend.auth.domain.Member;
 import com.aliens.backend.auth.domain.repository.MemberRepository;
 import com.aliens.backend.chat.controller.dto.event.ChatRoomBlockEvent;
 import com.aliens.backend.chat.controller.dto.event.ChatRoomCreationEvent;
+import com.aliens.backend.chat.controller.dto.event.ChatRoomExpireEvent;
 import com.aliens.backend.chat.controller.dto.request.MessageSendRequest;
 import com.aliens.backend.chat.controller.dto.request.ReadRequest;
 import com.aliens.backend.chat.controller.dto.response.ChatSummaryResponse;
@@ -12,6 +13,7 @@ import com.aliens.backend.chat.controller.dto.response.ReadResponse;
 import com.aliens.backend.chat.domain.ChatParticipant;
 import com.aliens.backend.chat.domain.ChatRoom;
 import com.aliens.backend.chat.domain.Message;
+import com.aliens.backend.chat.domain.repository.ChatParticipantRepository;
 import com.aliens.backend.chat.domain.repository.ChatRoomRepository;
 import com.aliens.backend.chat.domain.repository.MessageRepository;
 import com.aliens.backend.chat.service.model.ChatMessageSummary;
@@ -21,6 +23,7 @@ import com.aliens.backend.global.response.error.ChatError;
 import com.aliens.backend.global.response.error.MemberError;
 import com.aliens.backend.global.response.success.ChatSuccess;
 import com.aliens.backend.notification.domain.FcmTokenRepository;
+import jakarta.transaction.Transactional;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -37,19 +40,22 @@ public class ChatService {
     private final FcmTokenRepository fcmTokenRepository;
     private final MemberRepository memberRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final ChatParticipantRepository chatParticipantRepository;
 
     public ChatService(final MessageRepository messageRepository,
                        final SimpMessagingTemplate messagingTemplate,
                        final ChatRoomRepository chatRoomRepository,
                        final FcmTokenRepository fcmTokenRepository,
                        final MemberRepository memberRepository,
-                       final ApplicationEventPublisher eventPublisher) {
+                       final ApplicationEventPublisher eventPublisher,
+                       final ChatParticipantRepository chatParticipantRepository) {
         this.messageRepository = messageRepository;
         this.messagingTemplate = messagingTemplate;
         this.chatRoomRepository = chatRoomRepository;
         this.fcmTokenRepository = fcmTokenRepository;
         this.memberRepository = memberRepository;
         this.eventPublisher = eventPublisher;
+        this.chatParticipantRepository = chatParticipantRepository;
     }
 
     public String sendMessage(MessageSendRequest messageSendRequest) {

--- a/src/main/java/com/aliens/backend/global/config/interceptor/ChatChannelInterceptor.java
+++ b/src/main/java/com/aliens/backend/global/config/interceptor/ChatChannelInterceptor.java
@@ -5,8 +5,6 @@ import com.aliens.backend.chat.controller.dto.request.ReadRequest;
 import com.aliens.backend.chat.domain.ChatRoom;
 import com.aliens.backend.chat.service.ChatAuthValidator;
 import com.aliens.backend.global.property.WebSocketProperties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
@@ -23,8 +21,6 @@ public class ChatChannelInterceptor implements ChannelInterceptor {
 
     private final ChatAuthValidator chatAuthValidator;
     private final WebSocketProperties properties;
-    private final Logger logger = LoggerFactory.getLogger("웹소켓 요청");
-
     private MappingJackson2MessageConverter messageConverter = new MappingJackson2MessageConverter();
 
     public ChatChannelInterceptor(ChatAuthValidator chatAuthValidator, WebSocketProperties properties) {
@@ -35,7 +31,6 @@ public class ChatChannelInterceptor implements ChannelInterceptor {
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-        logger.info("preSend: {} - {}",accessor.getCommand(), accessor.getDestination());
 
         List<ChatRoom> chatRooms = (List<ChatRoom>) accessor.getSessionAttributes().get("chatRooms");
         if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {

--- a/src/main/java/com/aliens/backend/mathcing/service/MatchingProcessService.java
+++ b/src/main/java/com/aliens/backend/mathcing/service/MatchingProcessService.java
@@ -4,6 +4,7 @@ import com.aliens.backend.auth.controller.dto.LoginMember;
 import com.aliens.backend.auth.domain.Member;
 import com.aliens.backend.block.domain.Block;
 import com.aliens.backend.block.domain.repository.BlockRepository;
+import com.aliens.backend.chat.controller.dto.event.ChatRoomExpireEvent;
 import com.aliens.backend.chat.domain.ChatParticipant;
 import com.aliens.backend.chat.domain.ChatRoom;
 import com.aliens.backend.chat.domain.repository.ChatParticipantRepository;
@@ -94,10 +95,9 @@ public class MatchingProcessService {
     @Scheduled(cron = "${matching.round.end}")
     @Transactional
     public void expireMatching() {
-        List<MatchingResult> previousMatchingResults = getPreviousMatchingResults();
         List<MatchingApplication> previousMatchingApplications = getPreviousMatchingApplications();
         previousMatchingApplications.forEach(MatchingApplication::expireMatch);
-        eventPublisher.expireChatRoom(previousMatchingResults);
+        eventPublisher.expireChatRoom();
     }
 
     private void saveMatchingResult(final MatchingRound matchingRound, final List<Participant> participants) {

--- a/src/main/java/com/aliens/backend/mathcing/service/event/MatchingEventPublisher.java
+++ b/src/main/java/com/aliens/backend/mathcing/service/event/MatchingEventPublisher.java
@@ -4,7 +4,6 @@ import com.aliens.backend.chat.controller.dto.event.ChatRoomCreationEvent;
 import com.aliens.backend.chat.controller.dto.event.ChatRoomExpireEvent;
 import com.aliens.backend.chat.service.model.MemberPair;
 import com.aliens.backend.mathcing.business.model.Participant;
-import com.aliens.backend.mathcing.domain.MatchingResult;
 import com.aliens.backend.mathcing.service.model.MatchingNotificationMessage;
 import com.aliens.backend.mathcing.service.model.MemberPairGroup;
 import com.google.firebase.messaging.MulticastMessage;
@@ -28,10 +27,8 @@ public class MatchingEventPublisher {
         eventPublisher.publishEvent(new ChatRoomCreationEvent(matchedMemberPairs));
     }
 
-    public void expireChatRoom(List<MatchingResult> matchingResults) {
-        MemberPairGroup expiredMemberPairGroup = MemberPairGroup.fromMatchingResults(matchingResults);
-        Set<MemberPair> expiredMemberPairs = expiredMemberPairGroup.getMemberPairs();
-        eventPublisher.publishEvent(new ChatRoomExpireEvent(expiredMemberPairs));
+    public void expireChatRoom() {
+        eventPublisher.publishEvent(new ChatRoomExpireEvent());
     }
 
     public void sendNotification(List<Participant> participants) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,13 +10,20 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
     defer-datasource-initialization: true
 
   profiles:
     include: secret, matching
+
+logging:
+  level:
+    org.springframework.web.socket.config.WebSocketMessageBrokerStats: ERROR
 
 websocket:
   port: 8080
   endpoint: /ws
   topic: /room
   request: /chat
+
+

--- a/src/test/java/com/aliens/backend/chatting/socket/WebSocketTest.java
+++ b/src/test/java/com/aliens/backend/chatting/socket/WebSocketTest.java
@@ -71,11 +71,11 @@ class WebSocketTest extends BaseIntegrationTest {
         chatClient.send(properties.getAppDestinationPrefix() + "/send", messageSendRequest);
 
         //Then
-        verify(chatService, timeout(100).times(1)).sendMessage(messageSendRequest);
-        verify(chatChannelInterceptor, timeout(100).times(3)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND
-        verify(chatService, timeout(100).times(1)).getChatRooms(member.getId()); // CONNECT
-        verify(chatAuthValidator, timeout(100).times(1)).validateRoomFromTopic(any(), any()); // SUBSCRIBE
-        verify(chatAuthValidator, timeout(100).times(1)).validateRoom(any(), any()); // SEND
+        verify(chatService, timeout(1000).times(1)).sendMessage(messageSendRequest);
+        verify(chatChannelInterceptor, timeout(1000).times(3)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND
+        verify(chatService, timeout(1000).times(1)).getChatRooms(member.getId()); // CONNECT
+        verify(chatAuthValidator, timeout(1000).times(1)).validateRoomFromTopic(any(), any()); // SUBSCRIBE
+        verify(chatAuthValidator, timeout(1000).times(1)).validateRoom(any(), any()); // SEND
         Message receivedMessage = objectMapper.readValue((byte[]) receiveMessage.get(0), Message.class);
         Assertions.assertEquals(1, receiveMessage.size());
         Assertions.assertEquals(expectedMessage.getId(), receivedMessage.getId());
@@ -99,10 +99,10 @@ class WebSocketTest extends BaseIntegrationTest {
         chatClient.send(properties.getAppDestinationPrefix() + "/send", messageSendRequest);
 
         //Then
-        verify(chatChannelInterceptor, timeout(100).times(4)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND, 4. DISCONNECT
-        verify(chatService, timeout(100).times(1)).getChatRooms(member.getId());
-        verify(chatAuthValidator, timeout(100).times(1)).validateRoom(any(), any());
-        verify(chatController, timeout(100).times(0)).sendMessage(messageSendRequest); // 호출되지 않음
+        verify(chatChannelInterceptor, timeout(1000).times(4)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND, 4. DISCONNECT
+        verify(chatService, timeout(1000).times(1)).getChatRooms(member.getId());
+        verify(chatAuthValidator, timeout(1000).times(1)).validateRoom(any(), any());
+        verify(chatController, timeout(1000).times(0)).sendMessage(messageSendRequest); // 호출되지 않음
     }
 
     @Test
@@ -116,9 +116,9 @@ class WebSocketTest extends BaseIntegrationTest {
         chatClient.subscribe(unAuthorizedRoomId);
 
         //Then
-        verify(chatChannelInterceptor, timeout(100).times(3)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. DISCONNECT
-        verify(chatService, timeout(100).times(1)).getChatRooms(member.getId());
-        verify(chatAuthValidator, timeout(100).times(1)).validateRoomFromTopic(any(), any());
+        verify(chatChannelInterceptor, timeout(1000).times(3)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. DISCONNECT
+        verify(chatService, timeout(1000).times(1)).getChatRooms(member.getId());
+        verify(chatAuthValidator, timeout(1000).times(1)).validateRoomFromTopic(any(), any());
     }
 
     @Test
@@ -135,11 +135,11 @@ class WebSocketTest extends BaseIntegrationTest {
         chatClient.send(properties.getAppDestinationPrefix() + "/read", readRequest);
 
         //Then
-        verify(chatChannelInterceptor, timeout(100).times(3)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND
-        verify(chatController, timeout(100).times(1)).readMessage(readRequest);
-        verify(chatService, timeout(100).times(1)).getChatRooms(member.getId()); // CONNECT
-        verify(chatAuthValidator, timeout(100).times(1)).validateRoomFromTopic(any(), any()); // SUBSCRIBE
-        verify(chatAuthValidator, timeout(100).times(1)).validateRoom(any(), any()); // SEND
+        verify(chatChannelInterceptor, timeout(1000).times(3)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND
+        verify(chatController, timeout(1000).times(1)).readMessage(readRequest);
+        verify(chatService, timeout(1000).times(1)).getChatRooms(member.getId()); // CONNECT
+        verify(chatAuthValidator, timeout(1000).times(1)).validateRoomFromTopic(any(), any()); // SUBSCRIBE
+        verify(chatAuthValidator, timeout(1000).times(1)).validateRoom(any(), any()); // SEND
         ReadResponse receivedReadResponse = objectMapper.readValue((byte[]) receiveMessage.get(0), ReadResponse.class);
         Assertions.assertEquals(1, receiveMessage.size());
         Assertions.assertEquals(readResponse.readBy(), receivedReadResponse.readBy());
@@ -159,10 +159,10 @@ class WebSocketTest extends BaseIntegrationTest {
         chatClient.send(properties.getAppDestinationPrefix() + "/read", unAuthorizedReadRequest);
 
         //Then
-        verify(chatChannelInterceptor, timeout(100).times(4)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND, 4. DISCONNECT
-        verify(chatService, timeout(100).times(1)).getChatRooms(member.getId());
-        verify(chatAuthValidator, timeout(100).times(1)).validateRoom(any(), any());
-        verify(chatController, timeout(100).times(0)).readMessage(unAuthorizedReadRequest); // 호출되지 않음
+        verify(chatChannelInterceptor, timeout(1000).times(4)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND, 4. DISCONNECT
+        verify(chatService, timeout(1000).times(1)).getChatRooms(member.getId());
+        verify(chatAuthValidator, timeout(1000).times(1)).validateRoom(any(), any());
+        verify(chatController, timeout(1000).times(0)).readMessage(unAuthorizedReadRequest); // 호출되지 않음
     }
 
     private MessageSendRequest createMessageSendRequest(Long roomId) {

--- a/src/test/java/com/aliens/backend/chatting/socket/WebSocketTest.java
+++ b/src/test/java/com/aliens/backend/chatting/socket/WebSocketTest.java
@@ -71,11 +71,11 @@ class WebSocketTest extends BaseIntegrationTest {
         chatClient.send(properties.getAppDestinationPrefix() + "/send", messageSendRequest);
 
         //Then
-        verify(chatService, timeout(1000).times(1)).sendMessage(messageSendRequest);
-        verify(chatChannelInterceptor, timeout(1000).times(3)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND
-        verify(chatService, timeout(1000).times(1)).getChatRooms(member.getId()); // CONNECT
-        verify(chatAuthValidator, timeout(1000).times(1)).validateRoomFromTopic(any(), any()); // SUBSCRIBE
-        verify(chatAuthValidator, timeout(1000).times(1)).validateRoom(any(), any()); // SEND
+        verify(chatService, timeout(20000).times(1)).sendMessage(messageSendRequest);
+        verify(chatChannelInterceptor, timeout(20000).times(3)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND
+        verify(chatService, timeout(20000).times(1)).getChatRooms(member.getId()); // CONNECT
+        verify(chatAuthValidator, timeout(20000).times(1)).validateRoomFromTopic(any(), any()); // SUBSCRIBE
+        verify(chatAuthValidator, timeout(20000).times(1)).validateRoom(any(), any()); // SEND
         Message receivedMessage = objectMapper.readValue((byte[]) receiveMessage.get(0), Message.class);
         Assertions.assertEquals(1, receiveMessage.size());
         Assertions.assertEquals(expectedMessage.getId(), receivedMessage.getId());
@@ -99,10 +99,10 @@ class WebSocketTest extends BaseIntegrationTest {
         chatClient.send(properties.getAppDestinationPrefix() + "/send", messageSendRequest);
 
         //Then
-        verify(chatChannelInterceptor, timeout(1000).times(4)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND, 4. DISCONNECT
-        verify(chatService, timeout(1000).times(1)).getChatRooms(member.getId());
-        verify(chatAuthValidator, timeout(1000).times(1)).validateRoom(any(), any());
-        verify(chatController, timeout(1000).times(0)).sendMessage(messageSendRequest); // 호출되지 않음
+        verify(chatChannelInterceptor, timeout(20000).times(4)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND, 4. DISCONNECT
+        verify(chatService, timeout(20000).times(1)).getChatRooms(member.getId());
+        verify(chatAuthValidator, timeout(20000).times(1)).validateRoom(any(), any());
+        verify(chatController, timeout(20000).times(0)).sendMessage(messageSendRequest); // 호출되지 않음
     }
 
     @Test
@@ -116,9 +116,9 @@ class WebSocketTest extends BaseIntegrationTest {
         chatClient.subscribe(unAuthorizedRoomId);
 
         //Then
-        verify(chatChannelInterceptor, timeout(1000).times(3)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. DISCONNECT
-        verify(chatService, timeout(1000).times(1)).getChatRooms(member.getId());
-        verify(chatAuthValidator, timeout(1000).times(1)).validateRoomFromTopic(any(), any());
+        verify(chatChannelInterceptor, timeout(20000).times(3)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. DISCONNECT
+        verify(chatService, timeout(20000).times(1)).getChatRooms(member.getId());
+        verify(chatAuthValidator, timeout(20000).times(1)).validateRoomFromTopic(any(), any());
     }
 
     @Test
@@ -135,11 +135,11 @@ class WebSocketTest extends BaseIntegrationTest {
         chatClient.send(properties.getAppDestinationPrefix() + "/read", readRequest);
 
         //Then
-        verify(chatChannelInterceptor, timeout(1000).times(3)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND
-        verify(chatController, timeout(1000).times(1)).readMessage(readRequest);
-        verify(chatService, timeout(1000).times(1)).getChatRooms(member.getId()); // CONNECT
-        verify(chatAuthValidator, timeout(1000).times(1)).validateRoomFromTopic(any(), any()); // SUBSCRIBE
-        verify(chatAuthValidator, timeout(1000).times(1)).validateRoom(any(), any()); // SEND
+        verify(chatChannelInterceptor, timeout(20000).times(3)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND
+        verify(chatController, timeout(20000).times(1)).readMessage(readRequest);
+        verify(chatService, timeout(20000).times(1)).getChatRooms(member.getId()); // CONNECT
+        verify(chatAuthValidator, timeout(20000).times(1)).validateRoomFromTopic(any(), any()); // SUBSCRIBE
+        verify(chatAuthValidator, timeout(20000).times(1)).validateRoom(any(), any()); // SEND
         ReadResponse receivedReadResponse = objectMapper.readValue((byte[]) receiveMessage.get(0), ReadResponse.class);
         Assertions.assertEquals(1, receiveMessage.size());
         Assertions.assertEquals(readResponse.readBy(), receivedReadResponse.readBy());
@@ -159,10 +159,10 @@ class WebSocketTest extends BaseIntegrationTest {
         chatClient.send(properties.getAppDestinationPrefix() + "/read", unAuthorizedReadRequest);
 
         //Then
-        verify(chatChannelInterceptor, timeout(1000).times(4)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND, 4. DISCONNECT
-        verify(chatService, timeout(1000).times(1)).getChatRooms(member.getId());
-        verify(chatAuthValidator, timeout(1000).times(1)).validateRoom(any(), any());
-        verify(chatController, timeout(1000).times(0)).readMessage(unAuthorizedReadRequest); // 호출되지 않음
+        verify(chatChannelInterceptor, timeout(20000).times(4)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND, 4. DISCONNECT
+        verify(chatService, timeout(20000).times(1)).getChatRooms(member.getId());
+        verify(chatAuthValidator, timeout(20000).times(1)).validateRoom(any(), any());
+        verify(chatController, timeout(20000).times(0)).readMessage(unAuthorizedReadRequest); // 호출되지 않음
     }
 
     private MessageSendRequest createMessageSendRequest(Long roomId) {

--- a/src/test/java/com/aliens/backend/chatting/socket/WebSocketTest.java
+++ b/src/test/java/com/aliens/backend/chatting/socket/WebSocketTest.java
@@ -71,11 +71,11 @@ class WebSocketTest extends BaseIntegrationTest {
         chatClient.send(properties.getAppDestinationPrefix() + "/send", messageSendRequest);
 
         //Then
-        verify(chatService, timeout(20000).times(1)).sendMessage(messageSendRequest);
-        verify(chatChannelInterceptor, timeout(20000).times(3)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND
-        verify(chatService, timeout(20000).times(1)).getChatRooms(member.getId()); // CONNECT
-        verify(chatAuthValidator, timeout(20000).times(1)).validateRoomFromTopic(any(), any()); // SUBSCRIBE
-        verify(chatAuthValidator, timeout(20000).times(1)).validateRoom(any(), any()); // SEND
+        verify(chatService, timeout(50000).times(1)).sendMessage(messageSendRequest);
+        verify(chatChannelInterceptor, timeout(50000).times(3)).preSend(any(), any()); // 1. CONNECT, 2. SUBSCRIBE, 3. SEND
+        verify(chatService, timeout(50000).times(1)).getChatRooms(member.getId()); // CONNECT
+        verify(chatAuthValidator, timeout(50000).times(1)).validateRoomFromTopic(any(), any()); // SUBSCRIBE
+        verify(chatAuthValidator, timeout(50000).times(1)).validateRoom(any(), any()); // SEND
         Message receivedMessage = objectMapper.readValue((byte[]) receiveMessage.get(0), Message.class);
         Assertions.assertEquals(1, receiveMessage.size());
         Assertions.assertEquals(expectedMessage.getId(), receivedMessage.getId());

--- a/src/test/java/com/aliens/backend/docs/ChatRestDocsTest.java
+++ b/src/test/java/com/aliens/backend/docs/ChatRestDocsTest.java
@@ -72,10 +72,10 @@ class ChatRestDocsTest extends BaseRestDocsTest {
         List<ChatRoom> chatRooms = new ArrayList<>();
         ChatRoom chatRoom1 = mock(ChatRoom.class);
         when(chatRoom1.getId()).thenReturn(1L);
-        when(chatRoom1.getStatus()).thenReturn(ChatRoomStatus.OPEN);
+        when(chatRoom1.getStatus()).thenReturn(ChatRoomStatus.OPENED);
         ChatRoom chatRoom2 = mock(ChatRoom.class);
         when(chatRoom2.getId()).thenReturn(2L);
-        when(chatRoom2.getStatus()).thenReturn(ChatRoomStatus.OPEN);
+        when(chatRoom2.getStatus()).thenReturn(ChatRoomStatus.OPENED);
         chatRooms.add(chatRoom1);
         chatRooms.add(chatRoom2);
         Date now = new Date();


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #136 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- 만료 이벤트 수신시 모든 채팅방 상태 CLOSED로 업데이트
- 만료 이벤트 수신시 모든 채팅참가자 리스트 삭제
- 매칭 도메인 이벤트 파라미터 수정으로 인한 코드 수정

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 
