### PR TITLE
Fix/#143 채팅 요약 정보가 제대로 집계되지 않는 문제 수정

### DIFF
--- a/src/main/java/com/aliens/backend/chat/domain/repository/CustomMessageRepositoryImpl.java
+++ b/src/main/java/com/aliens/backend/chat/domain/repository/CustomMessageRepositoryImpl.java
@@ -54,9 +54,10 @@ public class CustomMessageRepositoryImpl implements CustomMessageRepository {
     public List<ChatMessageSummary> aggregateMessageSummaries(List<Long> chatRoomIds, Long memberId) {
         AggregationOperation match = Aggregation.match(Criteria.where("roomId").in(chatRoomIds));
         AggregationOperation group = Aggregation.group("roomId")
+                .last("roomId").as("roomId")
                 .last("content").as("lastMessageContent")
                 .last("sendTime").as("lastMessageTime")
-                .sum(ConditionalOperators.when(Criteria.where("receiverId").is(memberId).and("isRead").is(false)).then(1).otherwise(0)).as("unreadCount");
+                .sum(ConditionalOperators.when(Criteria.where("receiverId").is(memberId).and("isRead").is(false)).then(1).otherwise(0)).as("numberOfUnreadMessages");
         Aggregation aggregation = Aggregation.newAggregation(match, group);
         AggregationResults<ChatMessageSummary> results = mongoTemplate.aggregate(aggregation, "message", ChatMessageSummary.class);
         return new ArrayList<>(results.getMappedResults());


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #143 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- 채팅 요약 정보 집계시 aggregate 구문 roomId 필드 추가
- 채팅 요약 정보 집계시 aggregate 구문  unreadCount 필드 -> numberOfUnreadMessages 필드로 수정

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
aggregate를 사용할때, 필드 명시가 아닌 Aggregation.group("roomId")(단순 그룹화)으로만 명시했던터라 애초에 roomId를  필드까지 가지고 오지 못하는 것이 맞았네요..
as("unreadCount");도 현재 dto 필드와 동일하지 못해 발생한 정말 간단한 문제였어요
왜 몰랐을까 싶은데.. 이런걸 캐치 못한건 스스로도 채찍질이 필요해보이네요
복잡한 쿼리를 관리를 위해 aggregate문을 처음 도입할때 제대로 이해하지못한게 가장 컸던 것 같습니다. 앞으로는 처음 사용해보는 구문도 제대로 이해 후 활용하도록 하겠습니다 🥹

간단한 문제일거라고는 짐작했고.. 집계 코드 쪽 원인을 찾고부터는 진짜 단순한 문제라 바로 해결했는데, 원인 파악을 위해 로컬 매칭 + 디버깅 환경 구성까지 시간이 조금 걸렸던 것 같습니다.

😇 매칭 환경 구성을 도와주신 @suhyun0918 수현님께 정말 감사드립니다!🙇‍♂️😭✨ 덕분에 바로 끝낼 수 있었네요👍