### PR TITLE
Feat/#146 채팅 시작 시간에 맞춰 대기중 상태의 채팅방을 열린 상태로 업데이트

### DIFF
--- a/src/main/java/com/aliens/backend/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/aliens/backend/chat/domain/repository/ChatRoomRepository.java
@@ -16,4 +16,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     @Modifying
     @Query("UPDATE ChatRoom c SET c.status = com.aliens.backend.chat.domain.ChatRoomStatus.CLOSED")
     void expireAllChatRooms();
+
+    @Modifying
+    @Query("UPDATE ChatRoom c SET c.status = com.aliens.backend.chat.domain.ChatRoomStatus.OPENED WHERE c.status = com.aliens.backend.chat.domain.ChatRoomStatus.WAITING")
+    void openWaitingChatRooms();
 }

--- a/src/main/java/com/aliens/backend/chat/service/ChatService.java
+++ b/src/main/java/com/aliens/backend/chat/service/ChatService.java
@@ -27,6 +27,7 @@ import jakarta.transaction.Transactional;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -173,5 +174,11 @@ public class ChatService {
 
     private ChatRoom findChatRoomsById(final Long chatRoomId) {
         return chatRoomRepository.findById(chatRoomId).orElseThrow(() -> new RestApiException(ChatError.CHAT_ROOM_NOT_FOUND));
+    }
+
+    @Scheduled(cron = "${matching.round.update-date}")
+    @Transactional
+    public void openWaitingChatRooms() {
+        chatRoomRepository.openWaitingChatRooms();
     }
 }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #146 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- 채팅 시작 시간(화, 금 0시)에 맞춰 WAITING상태의 채팅방이 OPENED로 업데이트 되도록 스케쥴 추가

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 
