### PR TITLE
Fix/#158 매칭 완료 알림을 00시에 보낼 수 있도록 수정 

### DIFF
--- a/src/main/java/com/aliens/backend/mathcing/business/model/MatchingResultGroup.java
+++ b/src/main/java/com/aliens/backend/mathcing/business/model/MatchingResultGroup.java
@@ -1,9 +1,12 @@
 package com.aliens.backend.mathcing.business.model;
 
+import com.aliens.backend.auth.domain.Member;
 import com.aliens.backend.mathcing.domain.MatchingApplication;
 import com.aliens.backend.mathcing.domain.MatchingResult;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class MatchingResultGroup {
     private final List<MatchingResult> matchingResults;
@@ -21,5 +24,11 @@ public class MatchingResultGroup {
                 .filter(matchingResult -> matchingApplication.getMemberId().equals(matchingResult.getMatchingMemberId()))
                 .toList();
         return filteredMatchingResult;
+    }
+
+    public Set<Member> getMatchedMemberSet() {
+        return matchingResults.stream()
+                .map(MatchingResult::getMatchedMember)
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/com/aliens/backend/mathcing/business/model/Participant.java
+++ b/src/main/java/com/aliens/backend/mathcing/business/model/Participant.java
@@ -46,10 +46,6 @@ public record Participant(
         return partners.size();
     }
 
-    public String getFcmToken() {
-        return member().getFcmToken();
-    }
-
     public void addPartner(Relationship relationship, Participant participant) {
         partners.add(Partner.of(relationship, participant.member));
     }

--- a/src/main/java/com/aliens/backend/mathcing/service/MatchingProcessService.java
+++ b/src/main/java/com/aliens/backend/mathcing/service/MatchingProcessService.java
@@ -90,7 +90,6 @@ public class MatchingProcessService {
 
         if (hasMatchedParticipants(participants)) {
             eventPublisher.createChatRoom(participants);
-            eventPublisher.sendNotification(participants);
         }
     }
 

--- a/src/main/java/com/aliens/backend/mathcing/service/MatchingRoundService.java
+++ b/src/main/java/com/aliens/backend/mathcing/service/MatchingRoundService.java
@@ -12,6 +12,7 @@ import com.aliens.backend.mathcing.domain.repository.MatchingRoundRepository;
 import com.aliens.backend.mathcing.service.event.MatchingEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -39,7 +40,8 @@ public class MatchingRoundService {
     }
 
     @Scheduled(cron = "${matching.round.update-date}")
-    private void saveMatchRound() {
+    @Transactional
+    public void saveMatchRound() {
         MatchingRound matchingRound = MatchingRound.from(LocalDateTime.now(clock), matchingTimeProperties);
         matchingRoundRepository.save(matchingRound);
 
@@ -50,7 +52,9 @@ public class MatchingRoundService {
         List<MatchingResult> previousMatchingResults = findPreviousMatchingResults();
         MatchingResultGroup matchingResultGroup = MatchingResultGroup.of(previousMatchingResults);
         Set<Member> matchedMemberSet = matchingResultGroup.getMatchedMemberSet();
-        eventPublisher.sendMatchedNotification(matchedMemberSet);
+        if (!matchedMemberSet.isEmpty()) {
+            eventPublisher.sendMatchedNotification(matchedMemberSet);
+        }
     }
 
     private List<MatchingResult> findPreviousMatchingResults() {

--- a/src/main/java/com/aliens/backend/mathcing/service/MatchingRoundService.java
+++ b/src/main/java/com/aliens/backend/mathcing/service/MatchingRoundService.java
@@ -1,25 +1,40 @@
 package com.aliens.backend.mathcing.service;
 
+import com.aliens.backend.auth.domain.Member;
+import com.aliens.backend.global.exception.RestApiException;
 import com.aliens.backend.global.property.MatchingTimeProperties;
+import com.aliens.backend.global.response.error.MatchingError;
+import com.aliens.backend.mathcing.business.model.MatchingResultGroup;
+import com.aliens.backend.mathcing.domain.MatchingResult;
 import com.aliens.backend.mathcing.domain.MatchingRound;
+import com.aliens.backend.mathcing.domain.repository.MatchingResultRepository;
 import com.aliens.backend.mathcing.domain.repository.MatchingRoundRepository;
+import com.aliens.backend.mathcing.service.event.MatchingEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
 
 @Service
 public class MatchingRoundService {
     private final MatchingRoundRepository matchingRoundRepository;
+    private final MatchingResultRepository matchingResultRepository;
     private final MatchingTimeProperties matchingTimeProperties;
+    private final MatchingEventPublisher eventPublisher;
     private final Clock clock;
 
     public MatchingRoundService(final MatchingRoundRepository matchingRoundRepository,
+                                final MatchingResultRepository matchingResultRepository,
                                 final MatchingTimeProperties matchingTimeProperties,
+                                final MatchingEventPublisher eventPublisher,
                                 final Clock clock) {
         this.matchingRoundRepository = matchingRoundRepository;
+        this.matchingResultRepository = matchingResultRepository;
         this.matchingTimeProperties = matchingTimeProperties;
+        this.eventPublisher = eventPublisher;
         this.clock = clock;
     }
 
@@ -27,5 +42,25 @@ public class MatchingRoundService {
     private void saveMatchRound() {
         MatchingRound matchingRound = MatchingRound.from(LocalDateTime.now(clock), matchingTimeProperties);
         matchingRoundRepository.save(matchingRound);
+
+        sendMatchedNotification();
+    }
+
+    private void sendMatchedNotification() {
+        List<MatchingResult> previousMatchingResults = findPreviousMatchingResults();
+        MatchingResultGroup matchingResultGroup = MatchingResultGroup.of(previousMatchingResults);
+        Set<Member> matchedMemberSet = matchingResultGroup.getMatchedMemberSet();
+        eventPublisher.sendMatchedNotification(matchedMemberSet);
+    }
+
+    private List<MatchingResult> findPreviousMatchingResults() {
+        MatchingRound currentRound = findCurrentRound();
+        Long previousRound = currentRound.getPreviousRound();
+        return matchingResultRepository.findAllByRound(previousRound);
+    }
+
+    private MatchingRound findCurrentRound() {
+        return matchingRoundRepository.findCurrentRound()
+                .orElseThrow(()-> new RestApiException(MatchingError.NOT_FOUND_MATCHING_ROUND));
     }
 }

--- a/src/main/java/com/aliens/backend/mathcing/service/event/MatchingEventPublisher.java
+++ b/src/main/java/com/aliens/backend/mathcing/service/event/MatchingEventPublisher.java
@@ -1,5 +1,6 @@
 package com.aliens.backend.mathcing.service.event;
 
+import com.aliens.backend.auth.domain.Member;
 import com.aliens.backend.chat.controller.dto.event.ChatRoomCreationEvent;
 import com.aliens.backend.chat.controller.dto.event.ChatRoomExpireEvent;
 import com.aliens.backend.chat.service.model.MemberPair;
@@ -31,10 +32,8 @@ public class MatchingEventPublisher {
         eventPublisher.publishEvent(new ChatRoomExpireEvent());
     }
 
-    public void sendNotification(List<Participant> participants) {
-        List<Participant> participantsHasPartner = participants.stream()
-                .filter(Participant::hasPartner).toList();
-        MulticastMessage multicastMessage = MatchingNotificationMessage.createMulticastMessage(participantsHasPartner);
+    public void sendMatchedNotification(Set<Member> members) {
+        MulticastMessage multicastMessage = MatchingNotificationMessage.createMulticastMessage(members);
         eventPublisher.publishEvent(multicastMessage);
     }
 }

--- a/src/main/java/com/aliens/backend/mathcing/service/model/MatchingNotificationMessage.java
+++ b/src/main/java/com/aliens/backend/mathcing/service/model/MatchingNotificationMessage.java
@@ -1,16 +1,17 @@
 package com.aliens.backend.mathcing.service.model;
 
-import com.aliens.backend.mathcing.business.model.Participant;
+import com.aliens.backend.auth.domain.Member;
 import com.google.firebase.messaging.MulticastMessage;
 import com.google.firebase.messaging.Notification;
 
 import java.util.List;
+import java.util.Set;
 
 public record MatchingNotificationMessage(
 
 ) {
-    public static MulticastMessage createMulticastMessage(List<Participant> participants) {
-        List<String> participantFcmTokens = participants.stream().map(Participant::getFcmToken).toList();
+    public static MulticastMessage createMulticastMessage(Set<Member> members) {
+        List<String> participantFcmTokens = members.stream().map(Member::getFcmToken).toList();
         Notification notification = Notification.builder()
                 .setTitle("매칭이 완료되었습니다!")
                 .setBody("파트너를 확인해보세요!")

--- a/src/test/java/com/aliens/backend/matching/unit/service/MatchingProcessServiceTest.java
+++ b/src/test/java/com/aliens/backend/matching/unit/service/MatchingProcessServiceTest.java
@@ -98,16 +98,6 @@ class MatchingProcessServiceTest extends BaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("매칭 완료 후, 알림이 전송되는지 테스트")
-    void sendNotificationTest() {
-        // given & when
-        dummyGenerator.operateMatching();
-
-        // then
-        verify(fcmSender, times(1)).listenMultiMessageRequest(any());
-    }
-
-    @Test
     @DisplayName("연속 매칭 테스트")
     void operateMatchingTwice() {
         dummyGenerator.operateMatching();

--- a/src/test/java/com/aliens/backend/matching/unit/service/MatchingRoundServiceTest.java
+++ b/src/test/java/com/aliens/backend/matching/unit/service/MatchingRoundServiceTest.java
@@ -1,23 +1,40 @@
 package com.aliens.backend.matching.unit.service;
 
+import com.aliens.backend.auth.domain.Member;
 import com.aliens.backend.global.BaseIntegrationTest;
+import com.aliens.backend.global.DummyGenerator;
 import com.aliens.backend.global.exception.RestApiException;
 import com.aliens.backend.global.property.MatchingTimeProperties;
 import com.aliens.backend.global.response.error.MatchingError;
+import com.aliens.backend.matching.util.time.MockClock;
 import com.aliens.backend.matching.util.time.MockTime;
 import com.aliens.backend.mathcing.domain.MatchingRound;
+import com.aliens.backend.mathcing.domain.repository.MatchingResultRepository;
 import com.aliens.backend.mathcing.domain.repository.MatchingRoundRepository;
+import com.aliens.backend.mathcing.service.MatchingRoundService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.Clock;
 import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 class MatchingRoundServiceTest extends BaseIntegrationTest {
     @Autowired MatchingRoundRepository matchingRoundRepository;
     @Autowired MatchingTimeProperties matchingTimeProperties;
+    @Autowired MatchingResultRepository matchingResultRepository;
+    @Autowired MatchingRoundService matchingRoundService;
+    @Autowired DummyGenerator dummyGenerator;
+    @Autowired MockClock mockClock;
 
     @Test
     @DisplayName("매주 월, 목 매칭 회차 업데이트")
@@ -52,5 +69,23 @@ class MatchingRoundServiceTest extends BaseIntegrationTest {
     private MatchingRound getCurrentRound() {
         return matchingRoundRepository.findCurrentRound()
                 .orElseThrow(() -> new RestApiException(MatchingError.NOT_FOUND_MATCHING_ROUND));
+    }
+
+    @Test
+    @DisplayName("매칭 회차가 업데이트 된 00시에 매칭된 회원들에게 알림이 발송됨")
+    void sendMatchedNotification() {
+        Logger log = LoggerFactory.getLogger("테스트 로그");
+        // given
+        List<Member> members = dummyGenerator.generateMultiMember(5);
+        dummyGenerator.generateMatchingRound(MockTime.VALID_RECEPTION_TIME_ON_TUESDAY);
+        dummyGenerator.generateAppliersToMatch(members);
+        dummyGenerator.operateMatching();
+
+        // when
+        mockClock.mockTime(MockTime.FRIDAY);
+        matchingRoundService.saveMatchRound();
+
+        // then
+        verify(fcmSender, times(1)).listenMultiMessageRequest(any());
     }
 }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #158 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- 매칭 회차가 갱신될때 매칭된 회원들에게 일괄적으로 알림을 보낼 수 있도록 기능을 수정했습니다.
- 테스트도 성공적으로 완료했습니다. 

## 🙏 To Reviewers 
<!-- 리뷰어에게 전달할 말 -->
- 
