### PR TITLE
Feat/#160 게시글 단일조회 및 내림차순 조회 수정 

### DIFF
--- a/src/main/java/com/aliens/backend/board/controller/BoardController.java
+++ b/src/main/java/com/aliens/backend/board/controller/BoardController.java
@@ -43,6 +43,12 @@ public class BoardController {
     }
 
     @GetMapping
+    public SuccessResponse<BoardResponse> getSingleBoard(@RequestParam("boardId") final Long id) {
+        return SuccessResponse.of(BoardSuccess.GET_ALL_BOARDS_SUCCESS,
+                boardReadService.getSingleBoard(id));
+    }
+
+    @GetMapping
     public SuccessResponse<List<BoardResponse>> getAllBoards(@PageableDefault(sort = "boardId", direction = Sort.Direction.DESC) Pageable pageable) {
         return SuccessResponse.of(BoardSuccess.GET_ALL_BOARDS_SUCCESS,
                 boardReadService.getBoardPage(pageable));

--- a/src/main/java/com/aliens/backend/board/controller/BoardController.java
+++ b/src/main/java/com/aliens/backend/board/controller/BoardController.java
@@ -42,41 +42,41 @@ public class BoardController {
         return SuccessResponse.of(BoardSuccess.POST_BOARD_SUCCESS);
     }
 
-    @GetMapping
+    @GetMapping("/normal")
     public SuccessResponse<BoardResponse> getSingleBoard(@RequestParam("boardId") final Long id) {
         return SuccessResponse.of(BoardSuccess.GET_ALL_BOARDS_SUCCESS,
                 boardReadService.getSingleBoard(id));
     }
 
     @GetMapping
-    public SuccessResponse<List<BoardResponse>> getAllBoards(@PageableDefault(sort = "boardId", direction = Sort.Direction.DESC) Pageable pageable) {
+    public SuccessResponse<List<BoardResponse>> getAllBoards(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
         return SuccessResponse.of(BoardSuccess.GET_ALL_BOARDS_SUCCESS,
                 boardReadService.getBoardPage(pageable));
     }
 
     @GetMapping("/category")
     public SuccessResponse<List<BoardResponse>> getAllBoardsWithCategory(@RequestParam final String category,
-                                                                         @PageableDefault(sort = "boardId", direction = Sort.Direction.DESC) final Pageable pageable) {
+                                                                         @PageableDefault(sort = "id", direction = Sort.Direction.DESC) final Pageable pageable) {
         return SuccessResponse.of(BoardSuccess.GET_ALL_BOARDS_WITH_CATEGORY_SUCCESS,
                 boardReadService.getBoardPageWithCategory(category,pageable));
     }
 
     @GetMapping("/search")
     public SuccessResponse<List<BoardResponse>> searchAllBoardPage(@RequestParam("search-keyword") final String searchKeyword,
-                                                                   @PageableDefault(sort = "boardId", direction = Sort.Direction.DESC) final Pageable pageable) {
+                                                                   @PageableDefault(sort = "id", direction = Sort.Direction.DESC) final Pageable pageable) {
         return SuccessResponse.of(BoardSuccess.SEARCH_ALL_BOARDS_SUCCESS,
                 boardReadService.searchBoardPageWithKeyword(searchKeyword,pageable));
     }
 
     @GetMapping("/announcements")
-    public SuccessResponse<List<BoardResponse>> getAllAnnouncementBoards(@PageableDefault(sort = "boardId", direction = Sort.Direction.DESC) final Pageable pageable) {
+    public SuccessResponse<List<BoardResponse>> getAllAnnouncementBoards(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) final Pageable pageable) {
         return SuccessResponse.of(BoardSuccess.GET_ALL_ANNOUNCEMENT_BOARDS_SUCCESS,
                 boardReadService.getAnnouncePage(pageable));
     }
 
     @GetMapping("/writes")
     public SuccessResponse<List<BoardResponse>> getPageMyBoards(@Login LoginMember loginMember,
-                                                                @PageableDefault(sort = "boardId", direction = Sort.Direction.DESC) final Pageable pageable) {
+                                                                @PageableDefault(sort = "id", direction = Sort.Direction.DESC) final Pageable pageable) {
         return SuccessResponse.of(BoardSuccess.GET_MY_BOARD_PAGE_SUCCESS,
                 boardReadService.getMyBoardPage(loginMember, pageable));
     }
@@ -84,7 +84,7 @@ public class BoardController {
     @GetMapping("/category/search")
     public SuccessResponse<List<BoardResponse>> searchBoardsWithCategory(@RequestParam("search-keyword") final String searchKeyword,
                                                                          @RequestParam("category") final String category,
-                                                                         @PageableDefault(sort = "boardId", direction = Sort.Direction.DESC) final Pageable pageable) {
+                                                                         @PageableDefault(sort = "id", direction = Sort.Direction.DESC) final Pageable pageable) {
         return SuccessResponse.of(BoardSuccess.SEARCH_BOARD_WITH_CATEGORY_SUCCESS,
                 boardReadService.searchBoardPageWithKeywordAndCategory(searchKeyword, category, pageable));
     }

--- a/src/main/java/com/aliens/backend/board/controller/CommentController.java
+++ b/src/main/java/com/aliens/backend/board/controller/CommentController.java
@@ -43,7 +43,7 @@ public class CommentController {
 
     @GetMapping("/comments/my-boards")
     public SuccessResponse<List<BoardResponse>> getPageMyCommentedBoards(@Login final LoginMember loginMember,
-                                                                         @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+                                                                         @PageableDefault(sort = "id", direction = Sort.Direction.DESC) final Pageable pageable) {
         return SuccessResponse.of(CommentSuccess.GET_MY_COMMENTED_BOARD_PAGE_SUCCESS,
                 commentService.getCommentedBoardPage(loginMember, pageable));
     }

--- a/src/main/java/com/aliens/backend/board/controller/GreatController.java
+++ b/src/main/java/com/aliens/backend/board/controller/GreatController.java
@@ -33,7 +33,7 @@ public class GreatController {
 
     @GetMapping("/great/my-board")
     public SuccessResponse<List<BoardResponse>> getAllGreatBoards(@Login final LoginMember loginMember,
-                                                                  @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+                                                                  @PageableDefault(sort = "id", direction = Sort.Direction.DESC) final Pageable pageable) {
         return SuccessResponse.of(GreatSuccess.GET_ALL_GREAT_BOARDS_SUCCESS,
                 greatService.getGreatBoardPage(loginMember, pageable));
     }

--- a/src/main/java/com/aliens/backend/board/controller/MarketController.java
+++ b/src/main/java/com/aliens/backend/board/controller/MarketController.java
@@ -38,7 +38,7 @@ public class MarketController {
     }
 
     @GetMapping
-    public SuccessResponse<?> getMarketBoardPage(@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+    public SuccessResponse<?> getMarketBoardPage(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) final Pageable pageable) {
         return SuccessResponse.of(MarketBoardSuccess.GET_MARKET_BOARD_PAGE_SUCCESS,
                 boardReadService.getMarketBoardPage(pageable));
     }
@@ -51,7 +51,7 @@ public class MarketController {
 
     @GetMapping("/search")
     public SuccessResponse<?> searchMarketBoards(@RequestParam("search-keyword") final String searchKeyword,
-                                                     @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) final Pageable pageable) {
+                                                     @PageableDefault(sort = "id", direction = Sort.Direction.DESC) final Pageable pageable) {
         return SuccessResponse.of(MarketBoardSuccess.SEARCH_MARKET_BOARD_SUCCESS,
                 boardReadService.searchMarketBoardPage(searchKeyword, pageable));
     }

--- a/src/main/java/com/aliens/backend/board/domain/repository/custom/BoardCustomRepositoryImpl.java
+++ b/src/main/java/com/aliens/backend/board/domain/repository/custom/BoardCustomRepositoryImpl.java
@@ -6,8 +6,13 @@ import com.aliens.backend.board.controller.dto.response.MarketBoardResponse;
 import com.aliens.backend.board.domain.*;
 import com.aliens.backend.board.domain.enums.BoardCategory;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,114 +31,87 @@ public class BoardCustomRepositoryImpl implements BoardCustomRepository {
 
     @Override
     public List<BoardResponse> getBoardPage(final Pageable pageable) {
-        List<Tuple> results = queryFactory
+        JPAQuery<Tuple> query = queryFactory
                 .select(qBoard, qMember, qMember.memberImage)
                 .from(qBoard)
+
                 .leftJoin(qBoard.boardImages).fetchJoin()
                 .leftJoin(qBoard.member, qMember).fetchJoin()
-                .leftJoin(qMember.memberImage)
+                .leftJoin(qMember.memberImage);
 
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch()
-                .stream().distinct().toList();
-
-        return results.stream()
-                .map(tuple -> {
-                    Board board = tuple.get(qBoard);
-                    return board.getBoardResponse();
-                })
-                .toList();
+        List<Tuple> results = getPagingEntity(pageable, query);
+        return getBoardResponses(results);
     }
 
     @Override
     public List<BoardResponse> getBoardPageWithCategory(final BoardCategory category, Pageable pageable) {
-        List<Tuple> results = queryFactory
+        JPAQuery<Tuple> query = queryFactory
                 .select(qBoard, qMember, qMember.memberImage)
                 .from(qBoard)
+
                 .leftJoin(qBoard.boardImages).fetchJoin()
                 .leftJoin(qBoard.member, qMember).fetchJoin()
                 .leftJoin(qMember.memberImage)
 
-                .where(qBoard.category.eq(category))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch()
-                .stream().distinct().toList();
+                .where(qBoard.category.eq(category));
 
-        return results.stream()
-                .map(tuple -> {
-                    Board board = tuple.get(qBoard);
-                    return board.getBoardResponse();
-                })
-                .toList();
+        List<Tuple> results = getPagingEntity(pageable, query);
+        return getBoardResponses(results);
+
     }
 
     @Override
     public List<BoardResponse> searchBoardPageWithKeyword(final String keyword, final Pageable pageable) {
-        List<Tuple> results = queryFactory
+        JPAQuery<Tuple> query = queryFactory
                 .select(qBoard, qMember, qMember.memberImage)
                 .from(qBoard)
+
                 .leftJoin(qBoard.boardImages).fetchJoin()
                 .leftJoin(qBoard.member, qMember).fetchJoin()
                 .leftJoin(qMember.memberImage)
+
                 .where(qBoard.title.likeIgnoreCase("%" + keyword + "%")
-                        .or(qBoard.content.likeIgnoreCase("%" + keyword + "%")))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch()
-                .stream().distinct().toList();
+                        .or(qBoard.content.likeIgnoreCase("%" + keyword + "%")));
 
-
-        return results.stream()
-                .map(tuple -> {
-                    Board board = tuple.get(qBoard);
-                    return board.getBoardResponse();
-                })
-                .toList();
+        List<Tuple> results = getPagingEntity(pageable, query);
+        return getBoardResponses(results);
     }
 
     @Override
     public List<MarketBoardResponse> getMarketBoardPage(final Pageable pageable) {
-        List<Tuple> results = queryFactory
+        JPAQuery<Tuple> query = queryFactory
                 .select(qBoard, qBoard.marketInfo, qMember, qMember.memberImage)
                 .from(qBoard)
+
                 .leftJoin(qBoard.boardImages).fetchJoin()
                 .leftJoin(qBoard.member, qMember).fetchJoin()
                 .leftJoin(qMember.memberImage)
-                .where(qBoard.category.eq(BoardCategory.MARKET))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch()
-                .stream().distinct().toList();
 
+                .where(qBoard.category.eq(BoardCategory.MARKET));
 
-        return results.stream()
-                .map(tuple -> {
-                    Board board = tuple.get(qBoard);
-                    return board.getMarketBoardResponse();
-                })
-                .toList();
+        List<Tuple> results = getPagingEntity(pageable, query);
+        return getMarketBoardResponses(results);
     }
 
     @Override
     public List<MarketBoardResponse> searchMarketBoardPage(final String keyword, final Pageable pageable) {
-        List<Tuple> results = queryFactory
+        JPAQuery<Tuple> query = queryFactory
                 .select(qBoard, qBoard.marketInfo, qMember, qMember.memberImage)
                 .from(qBoard)
+
                 .leftJoin(qBoard.boardImages).fetchJoin()
                 .leftJoin(qBoard.member, qMember).fetchJoin()
                 .leftJoin(qMember.memberImage)
+
                 .where(qBoard.category.eq(BoardCategory.MARKET)
                         .and(qBoard.title.likeIgnoreCase("%" + keyword + "%")
-                                .or((qBoard.content.likeIgnoreCase("%" + keyword + "%")))))
+                                .or((qBoard.content.likeIgnoreCase("%" + keyword + "%")))));
 
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch()
-                .stream().distinct().toList();
+        List<Tuple> results = getPagingEntity(pageable, query);
+        return getMarketBoardResponses(results);
+    }
 
-
+    private List<MarketBoardResponse> getMarketBoardResponses(List<Tuple> results) {
         return results.stream()
                 .map(tuple -> {
                     Board board = tuple.get(qBoard);
@@ -144,47 +122,56 @@ public class BoardCustomRepositoryImpl implements BoardCustomRepository {
 
     @Override
     public List<BoardResponse> getMyBoardPage(Long memberId, Pageable pageable) {
-        List<Tuple> results = queryFactory
+
+        JPAQuery<Tuple> query = queryFactory
                 .select(qBoard, qBoard.marketInfo, qMember, qMember.memberImage)
                 .from(qBoard)
+
                 .leftJoin(qBoard.boardImages).fetchJoin()
                 .leftJoin(qBoard.member, qMember).fetchJoin()
                 .leftJoin(qMember.memberImage)
-                .where(qBoard.member.id.eq(memberId))
 
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch()
-                .stream().distinct().toList();
+                .where(qBoard.member.id.eq(memberId));
 
-
-        return results.stream()
-                .map(tuple -> {
-                    Board board = tuple.get(qBoard);
-                    return board.getBoardResponse();
-                })
-                .toList();
+        List<Tuple> results = getPagingEntity(pageable, query);
+        return getBoardResponses(results);
     }
 
     public List<BoardResponse> searchBoardPageWithKeywordAndCategory(String keyword,
                                                                      BoardCategory category,
                                                                      Pageable pageable) {
-        List<Tuple> results = queryFactory
+        JPAQuery<Tuple> query = queryFactory
                 .select(qBoard, qBoard.marketInfo, qMember, qMember.memberImage)
                 .from(qBoard)
+
                 .leftJoin(qBoard.boardImages).fetchJoin()
                 .leftJoin(qBoard.member, qMember).fetchJoin()
                 .leftJoin(qMember.memberImage)
+
                 .where(qBoard.category.eq(category)
                         .and(qBoard.title.likeIgnoreCase("%" + keyword + "%")
-                                .or((qBoard.content.likeIgnoreCase("%" + keyword + "%")))))
+                                .or((qBoard.content.likeIgnoreCase("%" + keyword + "%")))));
 
-                .offset(pageable.getOffset())
+        List<Tuple> results = getPagingEntity(pageable, query);
+        return getBoardResponses(results);
+    }
+
+    private List<Tuple> getPagingEntity(Pageable pageable, JPAQuery<Tuple> query) {
+        if (pageable.getSort().isSorted()) {
+            Sort.Order sortOrder = pageable.getSort().iterator().next();
+            PathBuilder pathBuilder = new PathBuilder(qBoard.getType(), qBoard.getMetadata());
+            Order direction = sortOrder.isAscending() ? Order.ASC : Order.DESC;
+            query.orderBy(new OrderSpecifier<>(direction, pathBuilder.get(sortOrder.getProperty())));
+        }
+
+        List<Tuple> results = query.offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch()
                 .stream().distinct().toList();
+        return results;
+    }
 
-
+    private List<BoardResponse> getBoardResponses(List<Tuple> results) {
         return results.stream()
                 .map(tuple -> {
                     Board board = tuple.get(qBoard);

--- a/src/main/java/com/aliens/backend/board/domain/repository/custom/GreatCustomRepositoryImpl.java
+++ b/src/main/java/com/aliens/backend/board/domain/repository/custom/GreatCustomRepositoryImpl.java
@@ -3,8 +3,13 @@ package com.aliens.backend.board.domain.repository.custom;
 import com.aliens.backend.board.controller.dto.response.BoardResponse;
 import com.aliens.backend.board.domain.*;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,7 +28,7 @@ public class GreatCustomRepositoryImpl implements GreatCustomRepository {
 
     @Override
     public List<BoardResponse> getGreatBoardPage(final Long memberId, final Pageable pageable) {
-        List<Tuple> results = queryFactory
+        JPAQuery<Tuple> query = queryFactory
                 .select(qBoard, qBoard.member.memberImage)
                 .from(qGreat)
 
@@ -32,13 +37,28 @@ public class GreatCustomRepositoryImpl implements GreatCustomRepository {
                 .leftJoin(qBoard.member).fetchJoin()
                 .leftJoin(qBoard.member.memberImage)
 
-                .where(qGreat.member.id.eq(memberId))
-                .offset(pageable.getOffset())
+                .where(qGreat.member.id.eq(memberId));
+
+        List<Tuple> results = getPagingEntity(pageable, query);
+        return getBoardResponses(results);
+    }
+
+    private List<Tuple> getPagingEntity(Pageable pageable, JPAQuery<Tuple> query) {
+        if (pageable.getSort().isSorted()) {
+            Sort.Order sortOrder = pageable.getSort().iterator().next();
+            PathBuilder pathBuilder = new PathBuilder(qBoard.getType(), qBoard.getMetadata());
+            Order direction = sortOrder.isAscending() ? Order.ASC : Order.DESC;
+            query.orderBy(new OrderSpecifier<>(direction, pathBuilder.get(sortOrder.getProperty())));
+        }
+
+        List<Tuple> results = query.offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch()
                 .stream().distinct().toList();
+        return results;
+    }
 
-
+    private List<BoardResponse> getBoardResponses(List<Tuple> results) {
         return results.stream()
                 .map(tuple -> {
                     Board board = tuple.get(qBoard);

--- a/src/main/java/com/aliens/backend/board/service/BoardReadService.java
+++ b/src/main/java/com/aliens/backend/board/service/BoardReadService.java
@@ -71,4 +71,9 @@ public class BoardReadService {
         BoardCategory boardCategory = BoardCategory.from(category);
         return boardCustomRepository.searchBoardPageWithKeywordAndCategory(searchKeyword, boardCategory, pageable);
     }
+
+    public BoardResponse getSingleBoard(Long id) {
+        Board board = getBoard(id);
+        return board.getBoardResponse();
+    }
 }

--- a/src/test/java/com/aliens/backend/docs/BoardRestDocsTest.java
+++ b/src/test/java/com/aliens/backend/docs/BoardRestDocsTest.java
@@ -82,7 +82,7 @@ class BoardRestDocsTest extends BaseRestDocsTest {
     @DisplayName("API - 전체 게시글 조회")
     void getAllBoardsTest() throws Exception {
         // Given
-        final Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "boardId"));
+        final Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "id"));
         final List<BoardResponse> boardResponses = List.of(
                 createBoardResponse(),
                 createBoardResponse());

--- a/src/test/java/com/aliens/backend/docs/MarketBoardRestDocsTest.java
+++ b/src/test/java/com/aliens/backend/docs/MarketBoardRestDocsTest.java
@@ -94,7 +94,7 @@ class MarketBoardRestDocsTest extends BaseRestDocsTest  {
     @DisplayName("API - 장터 게시글 조회")
     void getAllBoardsTest() throws Exception {
         // Given
-        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "id"));
         List<MarketBoardResponse> markets = List.of(
                 createMarketBoardResponse(),
                 createMarketBoardResponse());


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- #160 
- #161 

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- Pageable 객체에서 정의된 순서를 쿼리에서 적용하도록합니다.
- id 값을 기반으로 Board를 단일 조회하는 API를 추가합니다.

