### PR TITLE
fix (NotificationService) :  fcm 토큰 파싱 결과 변경

### DIFF
--- a/src/main/java/com/aliens/backend/notification/service/NotificationService.java
+++ b/src/main/java/com/aliens/backend/notification/service/NotificationService.java
@@ -60,8 +60,7 @@ public class NotificationService {
     }
 
     private String parseFcmToken(final String fcmToken) {
-        String[] parsed = fcmToken.split(":");
-        return parsed[1].substring( 1, parsed[1].length() - 1);
+        return fcmToken.substring(15, fcmToken.length()-2);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/aliens/backend/notification/NotificationServiceTest.java
+++ b/src/test/java/com/aliens/backend/notification/NotificationServiceTest.java
@@ -42,7 +42,7 @@ class NotificationServiceTest extends BaseIntegrationTest {
     @DisplayName("fcm토큰 저장")
     void registerFcmTokenTest() {
         //Given
-        String givenToken = "{fcmToken : fcmTokenExample}";
+        String givenToken = "{\"fcmToken\" : \"fcmTokenExample\"}";
         String expectedToken = "fcmTokenExample";
         //When
         notificationService.registerFcmToken(loginMember, givenToken);


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- 프론트에서 넘어오는 FCM 토큰이 Json형식의 Sring 값으로 들어와 알림 전송에 문제가 발생하였습니다.

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- 자체적으로 서버에서 해당 Json에 value값을 파싱합니다. 

