### PR TITLE
fix (MemberInfoService) : TCP 재요청으로 인한 중복회원 가입 방지

### DIFF
--- a/src/main/java/com/aliens/backend/board/service/CommentService.java
+++ b/src/main/java/com/aliens/backend/board/service/CommentService.java
@@ -54,10 +54,10 @@ public class CommentService {
         board.addComment(comment);
 
         commentRepository.save(comment);
-
-        if(!comment.isWriter(board.getWriterId())) {
-            fcmSender.sendParentCommentNotification(board,request);
-        }
+//
+//        if(!comment.isWriter(board.getWriterId())) {
+//            fcmSender.sendParentCommentNotification(board,request);
+//        }
     }
 
     private Board findBoard(final Long boardId) {
@@ -80,9 +80,9 @@ public class CommentService {
 
         commentRepository.save(childComment);
 
-        if(!parentComment.isWriter(member.getId())) {
-            fcmSender.sendChildCommentNotification(board, request, parentComment.getWriterId());
-        }
+//        if(!parentComment.isWriter(member.getId())) {
+//            fcmSender.sendChildCommentNotification(board, request, parentComment.getWriterId());
+//        }
     }
 
     private Comment findComment(ChildCommentCreateRequest request) {

--- a/src/main/java/com/aliens/backend/member/controller/dto/response/MemberResponse.java
+++ b/src/main/java/com/aliens/backend/member/controller/dto/response/MemberResponse.java
@@ -1,7 +1,7 @@
 package com.aliens.backend.member.controller.dto.response;
 
 public enum MemberResponse {
-
+    ALREADY_SIGN_UP("이미 회원 가입되어 있습니다."),
     SIGN_UP_SUCCESS("회원가입이 완료되었습니다."),
     WITHDRAW_SUCCESS("회원 탈퇴되었습니다."),
     TEMPORARY_PASSWORD_GENERATED_SUCCESS("임시 비밀번호가 발급되었습니다. 이메일을 확인해주세요."),

--- a/src/test/java/com/aliens/backend/docs/MemberRestDocsTest.java
+++ b/src/test/java/com/aliens/backend/docs/MemberRestDocsTest.java
@@ -33,7 +33,7 @@ class MemberRestDocsTest extends BaseRestDocsTest {
     @Test
     @DisplayName("API - 회원가입")
     void signUp() throws Exception {
-        final SignUpRequest request = createSignUpRequest();
+        final SignUpRequest request = createSampleSignUpRequest();
 
         final String message = MemberResponse.SIGN_UP_SUCCESS.getMessage();
         SuccessResponse<String> response = SuccessResponse.of(MemberSuccess.SIGN_UP_SUCCESS, message);
@@ -272,6 +272,19 @@ class MemberRestDocsTest extends BaseRestDocsTest {
 
     private SignUpRequest createSignUpRequest() {
         SignUpRequest signUpRequest = new SignUpRequest("tmp@example.com",
+                "password",
+                "tmpName",
+                "INTJ",
+                "MALE",
+                "KOREA",
+                "1998-11-25",
+                "반갑습니다"
+        );
+        return signUpRequest;
+    }
+
+    private SignUpRequest createSampleSignUpRequest() {
+        SignUpRequest signUpRequest = new SignUpRequest("tmp1@example.com",
                 "password",
                 "tmpName",
                 "INTJ",


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
- 이메일이 인증되더라도 회원가입 요청이 TCP 재전송으로 인해 중복 회원가입이 되는경우가 발생하였습니다.

## 🔑 Key Changes 
<!-- 주요 구현 사항 -->
- 만약 중복회원가입 시도라면, 에러를 뱉지않고 성공처리하도록 합니다.

